### PR TITLE
Guard OP_RETURN debug output

### DIFF
--- a/src/vm.c
+++ b/src/vm.c
@@ -284,11 +284,13 @@ static InterpretResult run() {
                         vmPush(&vm, returnValue);
                     }
 
-                    // For debugging, print the return value
+                    // For debugging, print the return value when tracing is enabled
+                    #ifdef DEBUG_TRACE_EXECUTION
                     printf("OUTPUT: Function returned: ");
                     printValue(returnValue);
                     printf("\n");
                     fflush(stdout);
+                    #endif
                 } else {
                     // If we're not in a function call, just push the return value back
                     vmPush(&vm, returnValue);


### PR DESCRIPTION
## Summary
- suppress debug prints in `OP_RETURN` unless `DEBUG_TRACE_EXECUTION` is enabled

## Testing
- `make orus`
- `bash tests/run_all_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_684046b3533483259a46da052d21f60a