### PR TITLE
Fix REPL to use global VM

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -9,8 +9,9 @@
 #include "parser.h"
 #include "vm.h"
 
+extern VM vm;
+
 static void repl() {
-    VM vm;
     char line[1024];
     for (;;) {
         printf("> ");


### PR DESCRIPTION
## Summary
- remove shadowing VM instance inside `repl`
- add `extern VM vm` declaration so `repl` uses the interpreter's global VM

## Testing
- `make orus`
- `printf 'print("Hi")\n' | ./orus`

------
https://chatgpt.com/codex/tasks/task_e_6840446688ac8325bbbf5c1ac2b02928