### PR TITLE
Remove unused function opcode

### DIFF
--- a/src/chunk.h
+++ b/src/chunk.h
@@ -73,7 +73,6 @@ typedef enum {
     // Function opcodes
     OP_CALL,
     OP_RETURN,
-    OP_DEFINE_FUNCTION,
 
     OP_POP,
     OP_PRINT,

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -1203,9 +1203,6 @@ static void generateCode(Compiler* compiler, ASTNode* node) {
             //         "DEBUG: Stored function position %d in global index %d\n",
             //         functionStart, node->data.function.index);
 
-            writeOp(compiler, OP_DEFINE_FUNCTION);
-            writeOp(compiler, node->data.function.index);
-
             break;
         }
         case AST_CALL: {

--- a/src/debug.c
+++ b/src/debug.c
@@ -144,9 +144,6 @@ int disassembleInstruction(Chunk* chunk, int offset) {
         case OP_NIL:
             return simpleInstruction("OP_NIL", offset);
 
-        case OP_DEFINE_FUNCTION:
-            return byteInstruction("OP_DEFINE_FUNCTION", chunk, offset);
-
         case OP_CALL: {
             uint8_t functionIndex = chunk->code[offset + 1];
             uint8_t argCount = chunk->code[offset + 2];

--- a/src/vm.c
+++ b/src/vm.c
@@ -449,11 +449,6 @@ static InterpretResult run() {
 
                 break;
             }
-            case OP_DEFINE_FUNCTION: {
-
-                break;
-            }
-
             case OP_CALL: {
                 uint8_t functionIndex = READ_BYTE();
                 uint8_t argCount = READ_BYTE();


### PR DESCRIPTION
## Summary
- drop the dead `OP_DEFINE_FUNCTION` opcode
- stop emitting `OP_DEFINE_FUNCTION` in the compiler
- remove the dispatch case from the VM and clean up disassembly
