### PR TITLE
Fix struct static call handling

### DIFF
--- a/include/ast.h
+++ b/include/ast.h
@@ -15,6 +15,9 @@ typedef enum {
     AST_CALL,
     AST_ARRAY,
     AST_ARRAY_SET,
+    AST_STRUCT_LITERAL,
+    AST_FIELD,
+    AST_FIELD_SET,
     AST_LET,
     AST_PRINT,
     AST_IF,
@@ -77,11 +80,24 @@ typedef struct {
 } ArrayData;
 
 typedef struct {
+    Token name;                 // Struct name
+    struct ASTNode* values;     // Linked list of field value expressions
+    int fieldCount;
+} StructLiteralData;
+
+typedef struct {
+    Token fieldName;            // Accessed field name
+    int index;                  // Resolved index within the struct
+} FieldAccessData;
+
+typedef struct {
     Token name;                // Function name
     struct ASTNode* parameters; // Linked list of parameter nodes
     Type* returnType;          // Return type
     struct ASTNode* body;      // Function body
     uint8_t index;             // Function index in the function table
+    bool isMethod;             // True if function has implicit self
+    Type* implType;            // Struct type if method
 } FunctionData;
 
 typedef struct {
@@ -117,9 +133,12 @@ typedef struct ASTNode {
         WhileData whileStmt;
         ForData forStmt;
         ArrayData array;
+        StructLiteralData structLiteral;
+        FieldAccessData field;
         struct {
             struct ASTNode* index;
         } arraySet;
+        FieldAccessData fieldSet;
         FunctionData function;
         CallData call;
         ReturnData returnStmt;
@@ -143,6 +162,9 @@ ASTNode* createCallNode(Token name, ASTNode* arguments, int argCount);
 ASTNode* createReturnNode(ASTNode* value);
 ASTNode* createArrayNode(ASTNode* elements, int elementCount);
 ASTNode* createArraySetNode(ASTNode* array, ASTNode* index, ASTNode* value);
+ASTNode* createStructLiteralNode(Token name, ASTNode* values, int fieldCount);
+ASTNode* createFieldAccessNode(ASTNode* object, Token name);
+ASTNode* createFieldSetNode(ASTNode* object, Token name, ASTNode* value);
 ASTNode* createBreakNode();
 ASTNode* createContinueNode();
 

--- a/include/parser.h
+++ b/include/parser.h
@@ -25,6 +25,7 @@ typedef struct {
     bool panicMode;
     Scanner* scanner;
     int functionDepth; // Track nested function declarations
+    Type* currentImplType; // Track struct type for methods
 } Parser;
 
 typedef ASTNode* (*ParseFn)(Parser*);

--- a/src/compiler/ast.c
+++ b/src/compiler/ast.c
@@ -167,6 +167,8 @@ ASTNode* createFunctionNode(Token name, ASTNode* parameters, Type* returnType, A
     node->data.function.returnType = returnType;
     node->data.function.body = body;
     node->data.function.index = 0; // Will be resolved during compilation
+    node->data.function.isMethod = false;
+    node->data.function.implType = NULL;
     node->valueType = NULL;
     return node;
 }
@@ -216,6 +218,43 @@ ASTNode* createArraySetNode(ASTNode* array, ASTNode* index, ASTNode* value) {
     node->right = array;
     node->next = NULL;
     node->data.arraySet.index = index;
+    node->valueType = NULL;
+    return node;
+}
+
+ASTNode* createStructLiteralNode(Token name, ASTNode* values, int fieldCount) {
+    ASTNode* node = (ASTNode*)malloc(sizeof(ASTNode));
+    node->type = AST_STRUCT_LITERAL;
+    node->left = NULL;
+    node->right = NULL;
+    node->next = NULL;
+    node->data.structLiteral.name = name;
+    node->data.structLiteral.values = values;
+    node->data.structLiteral.fieldCount = fieldCount;
+    node->valueType = NULL;
+    return node;
+}
+
+ASTNode* createFieldAccessNode(ASTNode* object, Token name) {
+    ASTNode* node = (ASTNode*)malloc(sizeof(ASTNode));
+    node->type = AST_FIELD;
+    node->left = object;
+    node->right = NULL;
+    node->next = NULL;
+    node->data.field.fieldName = name;
+    node->data.field.index = -1;
+    node->valueType = NULL;
+    return node;
+}
+
+ASTNode* createFieldSetNode(ASTNode* object, Token name, ASTNode* value) {
+    ASTNode* node = (ASTNode*)malloc(sizeof(ASTNode));
+    node->type = AST_FIELD_SET;
+    node->left = value;
+    node->right = object;
+    node->next = NULL;
+    node->data.fieldSet.fieldName = name;
+    node->data.fieldSet.index = -1;
     node->valueType = NULL;
     return node;
 }
@@ -277,8 +316,15 @@ void freeASTNode(ASTNode* node) {
     if (node->type == AST_ARRAY) {
         if (node->data.array.elements) freeASTNode(node->data.array.elements);
     }
+    if (node->type == AST_STRUCT_LITERAL) {
+        if (node->data.structLiteral.values)
+            freeASTNode(node->data.structLiteral.values);
+    }
     if (node->type == AST_ARRAY_SET) {
         if (node->data.arraySet.index) freeASTNode(node->data.arraySet.index);
+    }
+    if (node->type == AST_FIELD || node->type == AST_FIELD_SET) {
+        // children already freed via left/right
     }
     if (node->type == AST_CALL) {
         if (node->data.call.arguments) freeASTNode(node->data.call.arguments);


### PR DESCRIPTION
## Summary
- improve `.` call parsing so that calls on struct names don't pass the struct value