### PR TITLE
Fix stack/queue example compile error

### DIFF
--- a/stack_queue.orus
+++ b/stack_queue.orus
@@ -1,0 +1,141 @@
+// Implementation of Stack and Queue data structures using arrays and structs
+
+// A simple Stack implementation
+struct Stack {
+    data: [i32; 10],
+    top: i32
+}
+
+impl Stack {
+    fn new() -> Stack {
+        return Stack{
+            data: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            top: -1
+        }
+    }
+    
+    fn push(self, value: i32) -> bool {
+        if self.top >= 9 {
+            // Stack overflow
+            return false
+        }
+        
+        self.top = self.top + 1
+        self.data[self.top] = value
+        return true
+    }
+    
+    fn pop(self) -> i32 {
+        if self.top < 0 {
+            // Stack underflow
+            return -1
+        }
+        
+        let value: i32 = self.data[self.top]
+        self.top = self.top - 1
+        return value
+    }
+    
+    fn peek(self) -> i32 {
+        if self.top < 0 {
+            return -1
+        }
+        return self.data[self.top]
+    }
+    
+    fn is_empty(self) -> bool {
+        return self.top < 0
+    }
+    
+    fn size(self) -> i32 {
+        return self.top + 1
+    }
+}
+
+// A simple Queue implementation
+struct Queue {
+    data: [i32; 10],
+    front: i32,
+    rear: i32,
+    count: i32
+}
+
+impl Queue {
+    fn create() -> Queue {
+        return Queue{
+            data: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            front: 0,
+            rear: -1,
+            count: 0
+        }
+    }
+    
+    fn enqueue(self, value: i32) -> bool {
+        if self.count >= 10 {
+            // Queue is full
+            return false
+        }
+        
+        self.rear = (self.rear + 1) % 10
+        self.data[self.rear] = value
+        self.count = self.count + 1
+        return true
+    }
+    
+    fn dequeue(self) -> i32 {
+        if self.count <= 0 {
+            // Queue is empty
+            return -1
+        }
+        
+        let value: i32 = self.data[self.front]
+        self.front = (self.front + 1) % 10
+        self.count = self.count - 1
+        return value
+    }
+    
+    fn peek(self) -> i32 {
+        if self.count <= 0 {
+            return -1
+        }
+        return self.data[self.front]
+    }
+    
+    fn is_empty(self) -> bool {
+        return self.count == 0
+    }
+    
+    fn size(self) -> i32 {
+        return self.count
+    }
+}
+
+// Test the Stack implementation
+let stack: Stack = Stack.new()
+print("Stack created, isEmpty: {}", stack.is_empty())
+
+stack.push(10)
+stack.push(20)
+stack.push(30)
+print("Stack size after pushes: {}", stack.size())
+print("Stack top element: {}", stack.peek())
+
+let popped: i32 = stack.pop()
+print("Popped from stack: {}", popped)
+print("Stack size after pop: {}", stack.size())
+print("New stack top: {}", stack.peek())
+
+// Test the Queue implementation
+let queue: Queue = Queue.create()
+print("Queue created, isEmpty: {}", queue.is_empty())
+
+queue.enqueue(10)
+queue.enqueue(20)
+queue.enqueue(30)
+print("Queue size after enqueues: {}", queue.size())
+print("Queue front element: {}", queue.peek())
+
+let dequeued: i32 = queue.dequeue()
+print("Dequeued from queue: {}", dequeued)
+print("Queue size after dequeue: {}", queue.size())
+print("New queue front: {}", queue.peek())


### PR DESCRIPTION
## Summary
- add a `stack_queue.orus` example with stack and queue structs
- rename the queue initializer to `create` to avoid a static method name clash
- update print statements to use interpolation syntax

## Testing
- `./orus stack_queue.orus`

------
https://chatgpt.com/codex/tasks/task_e_684112fedeb08325a48e7820074811ec