### PR TITLE
Add runtime tracing toggle

### DIFF
--- a/include/vm.h
+++ b/include/vm.h
@@ -5,6 +5,7 @@
 #include "scanner.h"
 #include "type.h"
 #include "value.h"
+#include <stdbool.h>
 
 #define STACK_MAX 256
 #define FRAMES_MAX 64
@@ -62,6 +63,7 @@ typedef struct {
     // Garbage collector state
     Obj* objects;
     size_t bytesAllocated;
+    bool trace;
 } VM;
 
 typedef enum {

--- a/src/compiler/compiler.c
+++ b/src/compiler/compiler.c
@@ -2112,10 +2112,11 @@ bool compile(ASTNode* ast, Compiler* compiler) {
 
     writeOp(compiler, OP_RETURN);
     
-    // Only show code disassembly when debugging is enabled
-    #ifdef DEBUG_TRACE_EXECUTION
-    disassembleChunk(compiler->chunk, "code");
-    #endif
+    if (vm.trace) {
+#ifdef DEBUG_TRACE_EXECUTION
+        disassembleChunk(compiler->chunk, "code");
+#endif
+    }
     
     freeCompiler(compiler);
     return !compiler->hadError;

--- a/src/main.c
+++ b/src/main.c
@@ -124,20 +124,30 @@ static void runFile(const char* path) {
 }
 
 int main(int argc, const char* argv[]) {
-    if (argc == 2 && (strcmp(argv[1], "--version") == 0 || strcmp(argv[1], "-v") == 0)) {
-        printf("Orus %s\n", ORUS_VERSION);
-        return 0;
+    bool traceFlag = false;
+    const char* path = NULL;
+
+    for (int i = 1; i < argc; i++) {
+        if (strcmp(argv[i], "--version") == 0 || strcmp(argv[i], "-v") == 0) {
+            printf("Orus %s\n", ORUS_VERSION);
+            return 0;
+        } else if (strcmp(argv[i], "--trace") == 0) {
+            traceFlag = true;
+        } else if (!path) {
+            path = argv[i];
+        } else {
+            fprintf(stderr, "Usage: orus [--trace] [path]\n");
+            return 64;
+        }
     }
 
     initVM();
+    if (traceFlag) vm.trace = true;
 
-    if (argc == 1) {
+    if (!path) {
         repl();
-    } else if (argc == 2) {
-        runFile(argv[1]);
     } else {
-        fprintf(stderr, "Usage: orus [path]\n");
-        exit(64);
+        runFile(path);
     }
 
     freeVM();


### PR DESCRIPTION
## Summary
- add `vm.trace` flag and check ORUS_TRACE env var in `initVM`
- allow enabling tracing with `--trace` CLI flag
- show debug output when `vm.trace` is active