### PR TITLE
Improve syntax error reporting

### DIFF
--- a/include/scanner.h
+++ b/include/scanner.h
@@ -49,6 +49,7 @@ typedef struct {
 typedef struct {
     const char* start;
     const char* current;
+    const char* source;  // Pointer to the beginning of the entire source
     int line;
 } Scanner;
 
@@ -59,6 +60,10 @@ typedef struct {
 
 void init_scanner(const char* source);
 Token scan_token();
+
+// Expose the global scanner instance so other modules (like the parser)
+// can access the raw source when producing error messages.
+extern Scanner scanner;
 
 
 #endif

--- a/src/parser/parser.c
+++ b/src/parser/parser.c
@@ -40,6 +40,30 @@ static void block(Parser* parser, ASTNode** ast);
 static void consumeStatementEnd(Parser* parser);
 static void synchronize(Parser* parser);
 
+static void printErrorContext(Token* token) {
+    // Determine the start of the line containing the token
+    const char* lineStart = token->start;
+    while (lineStart > scanner.source && lineStart[-1] != '\n') {
+        lineStart--;
+    }
+
+    // Determine the end of the line
+    const char* lineEnd = token->start;
+    while (*lineEnd != '\n' && *lineEnd != '\0') {
+        lineEnd++;
+    }
+
+    int lineLength = (int)(lineEnd - lineStart);
+    fprintf(stderr, "%.*s\n", lineLength, lineStart);
+
+    // Print caret under the offending token
+    int column = (int)(token->start - lineStart);
+    for (int i = 0; i < column; i++) fputc(' ', stderr);
+    int caretLen = token->length > 0 ? token->length : 1;
+    for (int i = 0; i < caretLen; i++) fputc('^', stderr);
+    fputc('\n', stderr);
+}
+
 static void errorAt(Parser* parser, Token* token, const char* message) {
     if (parser->panicMode) return;
     parser->panicMode = true;
@@ -49,6 +73,7 @@ static void errorAt(Parser* parser, Token* token, const char* message) {
     else if (token->type != TOKEN_ERROR)
         fprintf(stderr, " at '%.*s'", token->length, token->start);
     fprintf(stderr, ": %s\n", message);
+    printErrorContext(token);
     parser->hadError = true;
 }
 

--- a/src/scanner/scanner.c
+++ b/src/scanner/scanner.c
@@ -60,6 +60,7 @@ void init_keyword_table() {
 void init_scanner(const char* source) {
     scanner.start = source;
     scanner.current = source;
+    scanner.source = source; // store the beginning of the entire source
     scanner.line = 1;
     init_keyword_table();
 }


### PR DESCRIPTION
## Summary
- expose the global `scanner` and store the start of the source
- enhance `errorAt` to print the offending line with a caret