### PR TITLE
Add stress tests and relax interpreter limits

### DIFF
--- a/include/vm.h
+++ b/include/vm.h
@@ -7,8 +7,9 @@
 #include "value.h"
 #include <stdbool.h>
 
-#define STACK_MAX 256
-#define FRAMES_MAX 64
+#define STACK_MAX 2048
+#define FRAMES_MAX 256
+#define LOOP_ITERATION_LIMIT 10000
 #define TRY_MAX 64
 
 typedef struct {

--- a/src/vm/vm.c
+++ b/src/vm/vm.c
@@ -195,7 +195,7 @@ static InterpretResult run() {
     #define READ_CONSTANT() (vm.chunk->constants.values[READ_BYTE()])
     
     // Define and reset loop safety counter at the start of each VM run
-    static int absolute_loop_count = 0;
+    static int absolute_loop_count = 0; // Tracks iterations across OP_LOOP
     absolute_loop_count = 0;
 
     InterpretResult result = INTERPRET_OK;
@@ -617,10 +617,11 @@ static InterpretResult run() {
                 // Use the global loop counter defined at the start of run()
                 absolute_loop_count++;
                 
-                // If the loop has iterated more than 1000 times, it's likely an infinite loop
-                if (absolute_loop_count > 200) {
-                    fprintf(stderr, "ERROR: Loop iteration limit exceeded (200). "
-                           "Forced termination to prevent infinite loop.\n");
+                // If the loop has iterated too many times, it's likely an infinite loop
+                if (absolute_loop_count > LOOP_ITERATION_LIMIT) {
+                    fprintf(stderr, "ERROR: Loop iteration limit exceeded (%d). "
+                           "Forced termination to prevent infinite loop.\n",
+                           LOOP_ITERATION_LIMIT);
                     return INTERPRET_RUNTIME_ERROR;
                 }
                 vm.ip -= offset;

--- a/tests/edge_cases/array_index_edges.orus
+++ b/tests/edge_cases/array_index_edges.orus
@@ -1,0 +1,14 @@
+// Test array indexing at boundary values and dynamic array expansions
+fn main() {
+    let arr: [i32; 3] = [10, 20, 30]
+    // Access first and last valid indices
+    print(arr[0])
+    print(arr[2])
+
+    // Dynamic array operations
+    let dyn: [i32; 1] = [5]
+    push(dyn, 6)
+    print(dyn[1])
+    pop(dyn)
+    print(len(dyn))
+}

--- a/tests/edge_cases/control_flow_edges.orus
+++ b/tests/edge_cases/control_flow_edges.orus
@@ -1,0 +1,25 @@
+// Test loop boundaries and break/continue behaviour
+fn main() {
+    // For loop with zero iterations
+    for i in 0..0 {
+        print(i)
+    }
+
+    // While loop that never executes
+    let count: i32 = 0
+    while count > 0 {
+        print(count)
+        count = count - 1
+    }
+
+    // Break and continue at edges
+    for j in 0..5 {
+        if j == 0 {
+            continue
+        }
+        if j == 3 {
+            break
+        }
+        print(j)
+    }
+}

--- a/tests/edge_cases/cyclic_references.orus
+++ b/tests/edge_cases/cyclic_references.orus
@@ -1,0 +1,15 @@
+// Simulate cyclic references using indices
+struct Node {
+    value: i32,
+    next: i32
+}
+
+fn main() {
+    let n1: Node = Node{value: 1, next: 1}
+    let n2: Node = Node{value: 2, next: 0}
+    let nodes: [Node; 2] = [n1, n2]
+
+    let start: i32 = 0
+    let second_index: i32 = nodes[start].next
+    print(nodes[second_index].value)
+}

--- a/tests/edge_cases/deep_recursion_stress.orus
+++ b/tests/edge_cases/deep_recursion_stress.orus
@@ -1,4 +1,4 @@
-// Deep recursion to approach stack limits
+// Recursion depth stress test nearing call stack limits
 fn recurse(n: i32) {
     if n <= 0 {
         return
@@ -7,6 +7,6 @@ fn recurse(n: i32) {
 }
 
 fn main() {
-    recurse(20)
+    recurse(70)
     print("done")
 }

--- a/tests/edge_cases/dynamic_array_stress.orus
+++ b/tests/edge_cases/dynamic_array_stress.orus
@@ -1,10 +1,10 @@
-// Grow a dynamic array beyond its initial capacity
+// Dynamic array stress test with large growth
 fn main() {
     let arr: [i32; 1] = [0]
-    for i in 1..20 {
+    for i in 1..1000 {
         push(arr, i)
     }
     print(len(arr))
     print(arr[0])
-    print(arr[19])
+    print(arr[999])
 }

--- a/tests/edge_cases/file_system_simulation.orus
+++ b/tests/edge_cases/file_system_simulation.orus
@@ -1,0 +1,25 @@
+// Simulate simple file system using structs and arrays
+struct File { name: string }
+struct Directory {
+    files: [File; 2],
+    count: i32
+}
+
+impl Directory {
+    fn new() -> Directory {
+        let f1: File = File{name: "a.txt"}
+        let f2: File = File{name: "b.txt"}
+        return Directory{files: [f1, f2], count: 2}
+    }
+
+    fn list(self) {
+        for i in 0..self.count {
+            print(self.files[i].name)
+        }
+    }
+}
+
+fn main() {
+    let dir: Directory = Directory.new()
+    dir.list()
+}

--- a/tests/edge_cases/function_module_edges.orus
+++ b/tests/edge_cases/function_module_edges.orus
@@ -1,0 +1,10 @@
+import "tests/edge_cases/module_a.orus"
+import "tests/edge_cases/module_b.orus"
+
+fn local_fn(a: i32, b: i32) -> i32 {
+    return a + b
+}
+
+fn main() {
+    print(local_fn(1, 2))
+}

--- a/tests/edge_cases/gc_edges.orus
+++ b/tests/edge_cases/gc_edges.orus
@@ -1,0 +1,9 @@
+// Stress garbage collector with many temporary arrays
+fn main() {
+    for i in 0..50 {
+        let arr: [i32; 5] = [1,2,3,4,5]
+        push(arr, i)
+        let _ = pop(arr)
+    }
+    print("done")
+}

--- a/tests/edge_cases/implementation_coverage.orus
+++ b/tests/edge_cases/implementation_coverage.orus
@@ -1,0 +1,24 @@
+// Exercise various language features together
+struct Pair { a: i32, b: i32 }
+
+impl Pair {
+    fn sum(self) -> i32 {
+        return self.a + self.b
+    }
+}
+
+fn compute(n: i32) -> i32 {
+    let total: i32 = 0
+    for i in 0..n {
+        total = total + i
+    }
+    return total
+}
+
+fn main() {
+    let p: Pair = Pair{a: 2, b: 3}
+    print(p.sum())
+    print(compute(5))
+    let arr: [i32; 2] = [7,8]
+    print(arr[1])
+}

--- a/tests/edge_cases/integer_overflow.orus
+++ b/tests/edge_cases/integer_overflow.orus
@@ -1,0 +1,5 @@
+// Attempt integer overflow
+fn main() {
+    let max: i32 = 2147483647
+    print(max + 1)
+}

--- a/tests/edge_cases/module_a.orus
+++ b/tests/edge_cases/module_a.orus
@@ -1,0 +1,3 @@
+fn main() {
+    print("Module A loaded")
+}

--- a/tests/edge_cases/module_b.orus
+++ b/tests/edge_cases/module_b.orus
@@ -1,0 +1,3 @@
+fn main() {
+    print("Module B loaded")
+}

--- a/tests/edge_cases/module_helper.orus
+++ b/tests/edge_cases/module_helper.orus
@@ -1,0 +1,3 @@
+fn main() {
+    print("Helper loaded")
+}

--- a/tests/edge_cases/module_imports.orus
+++ b/tests/edge_cases/module_imports.orus
@@ -1,0 +1,6 @@
+import "tests/edge_cases/module_a.orus"
+import "tests/edge_cases/module_b.orus"
+
+fn main() {
+    // Modules are imported for side effects only
+}

--- a/tests/edge_cases/nested_expressions.orus
+++ b/tests/edge_cases/nested_expressions.orus
@@ -1,0 +1,5 @@
+// Deeply nested arithmetic expression
+fn main() {
+    let result: i32 = ((((1 + 2) * 3) - 4) / 5) + (6 * (7 - (8 / 2)))
+    print(result)
+}

--- a/tests/edge_cases/nested_try_catch.orus
+++ b/tests/edge_cases/nested_try_catch.orus
@@ -1,0 +1,13 @@
+// Nested try/catch blocks
+fn main() {
+    try {
+        try {
+            let a = 10 / 0
+            print(a)
+        } catch inner {
+            print("inner error: {}", inner)
+        }
+    } catch outer {
+        print("outer error: {}", outer)
+    }
+}

--- a/tests/edge_cases/scope_shadowing.orus
+++ b/tests/edge_cases/scope_shadowing.orus
@@ -1,0 +1,9 @@
+// Variable shadowing across scopes
+fn main() {
+    let x: i32 = 5
+    if true {
+        let x_inner: i32 = 10
+        print(x_inner)
+    }
+    print(x)
+}

--- a/tests/edge_cases/self_referential.orus
+++ b/tests/edge_cases/self_referential.orus
@@ -1,0 +1,12 @@
+// Simple recursive function to test self references
+fn countdown(n: i32) {
+    if n <= 0 {
+        return
+    }
+    countdown(n - 1)
+}
+
+fn main() {
+    countdown(5)
+    print("done")
+}

--- a/tests/edge_cases/string_concat_stress.orus
+++ b/tests/edge_cases/string_concat_stress.orus
@@ -1,0 +1,8 @@
+// Build up a large string through repeated concatenation
+fn main() {
+    let text: string = ""
+    for i in 0..500 {
+        text = text + "a"
+    }
+    print(len(text))
+}

--- a/tests/edge_cases/string_edge_cases.orus
+++ b/tests/edge_cases/string_edge_cases.orus
@@ -1,0 +1,9 @@
+// Test empty and quoted strings
+fn main() {
+    let empty: string = ""
+    print(empty)
+    let quotes: string = "double and single quotes"
+    print(quotes)
+    let concat = "a" + "b" + "c" + "d" + "e"
+    print(concat)
+}

--- a/tests/edge_cases/struct_method_edges.orus
+++ b/tests/edge_cases/struct_method_edges.orus
@@ -1,0 +1,26 @@
+// Methods calling other methods
+struct Counter { value: i32 }
+
+impl Counter {
+    fn new(v: i32) -> Counter {
+        return Counter{value: v}
+    }
+
+    fn inc(self) {
+        self.value = self.value + 1
+    }
+
+    fn get(self) -> i32 {
+        return self.value
+    }
+
+    fn inc_and_get(self) -> i32 {
+        self.inc()
+        return self.get()
+    }
+}
+
+fn main() {
+    let c: Counter = Counter.new(0)
+    print(c.inc_and_get())
+}

--- a/tests/edge_cases/type_conversion.orus
+++ b/tests/edge_cases/type_conversion.orus
@@ -1,0 +1,8 @@
+// Mixed type arithmetic and string conversions
+fn main() {
+    let i: i32 = 5
+    let f: f64 = 2.5
+    print(i + f)
+    let text: string = "number:" + i
+    print(text)
+}


### PR DESCRIPTION
## Summary
- increase stack size, frame count and loop iteration limit
- guard loops with the new constant in the VM
- add edge case programs that push recursion depth, array growth and string concatenation