### PR TITLE
Add source location tracking for runtime errors

### DIFF
--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -376,6 +376,10 @@ Error types:
 - Type errors (e.g., incompatible types in an operation)
 - I/O errors (e.g., failed file operations)
 
+Error messages include the location of the failure using the format
+`file:line:column: message`. When an error unwinds through function calls,
+a short stack trace is printed showing the call chain.
+
 ## Generics
 
 The Orus language itself doesn't have generic syntax, but the C interpreter implementation provides macro-based generic data structures for internal use:

--- a/include/error.h
+++ b/include/error.h
@@ -3,6 +3,7 @@
 
 #include "common.h"
 #include "value.h"
+#include "location.h"
 
 typedef enum {
     ERROR_RUNTIME,
@@ -14,8 +15,9 @@ typedef struct ObjError {
     Obj obj;
     ErrorType type;
     ObjString* message;
+    SrcLocation location;
 } ObjError;
 
-ObjError* allocateError(ErrorType type, const char* message);
+ObjError* allocateError(ErrorType type, const char* message, SrcLocation location);
 
 #endif // ORUS_ERROR_H

--- a/include/location.h
+++ b/include/location.h
@@ -1,0 +1,10 @@
+#ifndef ORUS_LOCATION_H
+#define ORUS_LOCATION_H
+
+typedef struct {
+    const char* file;
+    int line;
+    int column;
+} SrcLocation;
+
+#endif // ORUS_LOCATION_H

--- a/include/memory.h
+++ b/include/memory.h
@@ -65,7 +65,7 @@ ObjString* allocateString(const char* str, int length);
 // Allocate a new array object with the given length
 ObjArray* allocateArray(int length);
 ObjIntArray* allocateIntArray(int length);
-struct ObjError* allocateError(ErrorType type, const char* message);
+struct ObjError* allocateError(ErrorType type, const char* message, SrcLocation location);
 
 // Allocate AST and Type objects
 struct ASTNode* allocateASTNode();

--- a/include/vm.h
+++ b/include/vm.h
@@ -79,6 +79,7 @@ InterpretResult interpret(const char* source);
 InterpretResult runChunk(Chunk* chunk);  // Execute a pre-compiled chunk
 void push(Value value);
 Value pop();
+void vmPrintStackTrace(void);
 
 extern Type* variableTypes[UINT8_COUNT];
 

--- a/src/main.c
+++ b/src/main.c
@@ -12,6 +12,12 @@
 #include "../include/error.h"
 #include "../include/version.h"
 
+static void printError(ObjError* err) {
+    fprintf(stderr, "%s:%d:%d: %s\n", err->location.file, err->location.line,
+            err->location.column, err->message->chars);
+    vmPrintStackTrace();
+}
+
 extern VM vm;
 
 static void repl() {
@@ -72,11 +78,11 @@ static void repl() {
         if (result == INTERPRET_COMPILE_ERROR) {
             printf("Compile error.\n");
         } else if (result == INTERPRET_RUNTIME_ERROR) {
-            printf("Runtime error: ");
             if (IS_ERROR(vm.lastError)) {
-                printf("%s", AS_ERROR(vm.lastError)->message->chars);
+                printError(AS_ERROR(vm.lastError));
+            } else {
+                printf("Runtime error.\n");
             }
-            printf("\n");
         } else if (!isPrintStmt && vm.stackTop > vm.stack) {
             // Print the result of the expression if there's a value on the stack
             // and it's not a print statement (which already outputs its value)
@@ -121,7 +127,7 @@ static void runFile(const char* path) {
     free(source);
     if (result == INTERPRET_RUNTIME_ERROR) {
         if (IS_ERROR(vm.lastError)) {
-            fprintf(stderr, "Runtime error: %s\n", AS_ERROR(vm.lastError)->message->chars);
+            printError(AS_ERROR(vm.lastError));
         }
         exit(70);
     }

--- a/src/vm/memory.c
+++ b/src/vm/memory.c
@@ -65,10 +65,11 @@ ObjIntArray* allocateIntArray(int length) {
     return array;
 }
 
-ObjError* allocateError(ErrorType type, const char* message) {
+ObjError* allocateError(ErrorType type, const char* message, SrcLocation location) {
     ObjError* err = (ObjError*)allocateObject(sizeof(ObjError), OBJ_ERROR);
     err->type = type;
     err->message = allocateString(message, (int)strlen(message));
+    err->location = location;
     return err;
 }
 


### PR DESCRIPTION
## Summary
- add `SrcLocation` struct and support storing locations in `ObjError`
- extend memory management and VM to handle new error information
- introduce `RUNTIME_ERROR` macro to include source location automatically
- print error locations and stack traces in main program
- document new error format in language reference