### PR TITLE
Add escape sequence handling

### DIFF
--- a/src/scanner/scanner.c
+++ b/src/scanner/scanner.c
@@ -273,7 +273,11 @@ static Token string() {
         if (peek() == '\\') {
             advance();
             switch (peek()) {
-                case 'n': advance();  // New line
+                case 'n':
+                case 't':
+                case '\\':
+                case '"':
+                    advance();
                     break;
                 default:
                     return error_token("Invalid escape sequence.");

--- a/tests/strings/escape_sequences.orus
+++ b/tests/strings/escape_sequences.orus
@@ -1,0 +1,7 @@
+fn main() {
+    print("Hello\nWorld")
+    print("Column A\tColumn B")
+    print("A backslash: \\")
+    print("He said: \"Hello\"")
+}
+


### PR DESCRIPTION
## Summary
- support escape sequences in scanner and parser
- add a regression test for escape sequences

## Testing
- `make`
- `tests/run_all_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_684307e1e280832590270ffa91324c02