### PR TITLE
Implement basic generic substitution

### DIFF
--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -382,19 +382,28 @@ a short stack trace is printed showing the call chain.
 
 ## Generics
 
-The Orus language itself doesn't have generic syntax, but the C interpreter implementation provides macro-based generic data structures for internal use:
+Orus functions and structs can take generic type parameters. Generic parameters
+are declared after the name using angle brackets and can be referenced within
+the definition. Type arguments may be supplied at call sites.
 
-```c
-// C macro to define type-specific array operations
-DEFINE_ARRAY_TYPE(int, Int);
+```orus
+fn id<T>(x: T) -> T {
+    return x
+}
 
-IntArray array;
-initIntArray(&array);
-writeIntArray(&array, 42);
-freeIntArray(&array);
+struct Box<T> {
+    value: T,
+}
+
+fn main() {
+    print(id<i32>(1))
+    print(id<string>("hi"))
+    let b: Box<i32> = Box { value: 2 }
+    print(b.value)
+}
 ```
 
-This feature is primarily for internal interpreter development, not for Orus language users.
-
-For more details on this implementation approach, see `docs/GENERICS.md`.
+Generic parameters are checked during compilation and must be supplied or can
+be inferred from argument types. The compiler verifies that generic arguments
+match usage within the function or struct.
 

--- a/include/ast.h
+++ b/include/ast.h
@@ -106,6 +106,8 @@ typedef struct {
     bool isMethod;             // True if function has implicit self
     Type* implType;            // Struct type if method
     ObjString* mangledName;    // GC-managed mangled name
+    ObjString** genericParams; // Generic parameter names
+    int genericCount;
 } FunctionData;
 
 typedef struct {
@@ -116,6 +118,9 @@ typedef struct {
     int argCount;             // Number of arguments
     Type* staticType;         // Struct type if called as Struct.fn
     ObjString* mangledName;    // GC-managed mangled name if method call
+    int nativeIndex;           // -1 if not a native function
+    Type** genericArgs;        // Generic argument types
+    int genericArgCount;
 } CallData;
 
 typedef struct {
@@ -177,8 +182,11 @@ ASTNode* createIfNode(ASTNode* condition, ASTNode* thenBranch, ASTNode* elifCond
 ASTNode* createBlockNode(ASTNode* statements, bool scoped);
 ASTNode* createWhileNode(ASTNode* condition, ASTNode* body);
 ASTNode* createForNode(Token iteratorName, ASTNode* startExpr, ASTNode* endExpr, ASTNode* stepExpr, ASTNode* body);
-ASTNode* createFunctionNode(Token name, ASTNode* parameters, Type* returnType, ASTNode* body);
-ASTNode* createCallNode(Token name, ASTNode* arguments, int argCount, Type* staticType);
+ASTNode* createFunctionNode(Token name, ASTNode* parameters, Type* returnType,
+                            ASTNode* body, ObjString** generics,
+                            int genericCount);
+ASTNode* createCallNode(Token name, ASTNode* arguments, int argCount, Type* staticType,
+                        Type** genericArgs, int genericArgCount);
 ASTNode* createTryNode(ASTNode* tryBlock, Token errorName, ASTNode* catchBlock);
 ASTNode* createReturnNode(ASTNode* value);
 ASTNode* createArrayNode(ASTNode* elements, int elementCount);

--- a/include/chunk.h
+++ b/include/chunk.h
@@ -82,6 +82,7 @@ typedef enum {
 
     // Function opcodes
     OP_CALL,
+    OP_CALL_NATIVE,
     OP_RETURN,
 
     OP_POP,

--- a/include/parser.h
+++ b/include/parser.h
@@ -26,6 +26,9 @@ typedef struct {
     Scanner* scanner;
     int functionDepth; // Track nested function declarations
     Type* currentImplType; // Track struct type for methods
+    ObjString** genericParams;
+    int genericCount;
+    int genericCapacity;
 } Parser;
 
 typedef ASTNode* (*ParseFn)(Parser*);

--- a/include/type.h
+++ b/include/type.h
@@ -14,6 +14,7 @@ typedef enum {
     TYPE_ARRAY,
     TYPE_FUNCTION,
     TYPE_STRUCT,
+    TYPE_GENERIC,
     TYPE_COUNT
 } TypeKind;
 
@@ -38,14 +39,21 @@ typedef struct Type {
             ObjString* name;
             FieldInfo* fields;
             int fieldCount;
+            ObjString** genericParams;
+            int genericCount;
         } structure;
+        struct {
+            ObjString* name;
+        } generic;
     } info;
 } Type;
 
 Type* createPrimitiveType(TypeKind kind);
 Type* createArrayType(Type* elementType);
 Type* createFunctionType(Type* returnType, Type** paramTypes, int paramCount);
-Type* createStructType(ObjString* name, FieldInfo* fields, int fieldCount);
+Type* createStructType(ObjString* name, FieldInfo* fields, int fieldCount,
+                       ObjString** generics, int genericCount);
+Type* createGenericType(ObjString* name);
 Type* findStructType(const char* name);
 void freeType(Type* type);
 bool typesEqual(Type* a, Type* b);
@@ -54,6 +62,8 @@ void initTypeSystem(void);
 void freeTypeSystem(void);  // Add this
 Type* getPrimitiveType(TypeKind kind);
 void markTypeRoots();
+Type* substituteGenerics(Type* type, ObjString** names, Type** subs, int count);
+Type* instantiateStructType(Type* base, Type** args, int argCount);
 
 extern Type* primitiveTypes[TYPE_COUNT];
 

--- a/include/vm.h
+++ b/include/vm.h
@@ -11,6 +11,16 @@
 #define FRAMES_MAX 256
 #define LOOP_ITERATION_LIMIT 10000
 #define TRY_MAX 64
+#define MAX_NATIVES 64
+
+typedef Value (*NativeFn)(int argCount, Value* args);
+
+typedef struct {
+    ObjString* name;
+    NativeFn function;
+    int arity;      // -1 for variadic
+    Type* returnType;
+} NativeFunction;
 
 typedef struct {
     int start;          // Bytecode offset of the function body
@@ -48,6 +58,7 @@ typedef struct {
 
     Function functions[UINT8_COUNT];
     uint16_t functionCount;
+    struct ASTNode* functionDecls[UINT8_COUNT];
 
     // Call frames for function calls
     CallFrame frames[FRAMES_MAX];
@@ -60,6 +71,9 @@ typedef struct {
 
     ObjString* loadedModules[UINT8_COUNT];
     uint8_t moduleCount;
+
+    NativeFunction nativeFunctions[MAX_NATIVES];
+    int nativeFunctionCount;
 
     // Garbage collector state
     Obj* objects;
@@ -80,6 +94,10 @@ InterpretResult runChunk(Chunk* chunk);  // Execute a pre-compiled chunk
 void push(Value value);
 Value pop();
 void vmPrintStackTrace(void);
+
+// Native function helpers
+void defineNative(const char* name, NativeFn function, int arity, Type* returnType);
+int findNative(ObjString* name);
 
 extern Type* variableTypes[UINT8_COUNT];
 

--- a/src/compiler/ast.c
+++ b/src/compiler/ast.c
@@ -157,7 +157,8 @@ ASTNode* createForNode(Token iteratorName, ASTNode* startExpr, ASTNode* endExpr,
     return node;
 }
 
-ASTNode* createFunctionNode(Token name, ASTNode* parameters, Type* returnType, ASTNode* body) {
+ASTNode* createFunctionNode(Token name, ASTNode* parameters, Type* returnType,
+                            ASTNode* body, ObjString** generics, int genericCount) {
     ASTNode* node = allocateASTNode();
     node->type = AST_FUNCTION;
     node->left = NULL;
@@ -171,11 +172,14 @@ ASTNode* createFunctionNode(Token name, ASTNode* parameters, Type* returnType, A
     node->data.function.isMethod = false;
     node->data.function.implType = NULL;
     node->data.function.mangledName = NULL;
+    node->data.function.genericParams = generics;
+    node->data.function.genericCount = genericCount;
     node->valueType = NULL;
     return node;
 }
 
-ASTNode* createCallNode(Token name, ASTNode* arguments, int argCount, Type* staticType) {
+ASTNode* createCallNode(Token name, ASTNode* arguments, int argCount, Type* staticType,
+                        Type** genericArgs, int genericArgCount) {
     ASTNode* node = allocateASTNode();
     node->type = AST_CALL;
     node->left = NULL;
@@ -188,6 +192,9 @@ ASTNode* createCallNode(Token name, ASTNode* arguments, int argCount, Type* stat
     node->data.call.argCount = argCount;
     node->data.call.staticType = staticType;
     node->data.call.mangledName = NULL;
+    node->data.call.nativeIndex = -1;
+    node->data.call.genericArgs = genericArgs;
+    node->data.call.genericArgCount = genericArgCount;
     node->valueType = NULL;
     return node;
 }

--- a/src/vm/debug.c
+++ b/src/vm/debug.c
@@ -168,6 +168,13 @@ int disassembleInstruction(Chunk* chunk, int offset) {
             return offset + 3;
         }
 
+        case OP_CALL_NATIVE: {
+            uint8_t index = chunk->code[offset + 1];
+            uint8_t argCount = chunk->code[offset + 2];
+            printf("%-16s %4d %4d\n", "OP_CALL_NATIVE", index, argCount);
+            return offset + 3;
+        }
+
         case OP_I32_TO_F64:
             return simpleInstruction("OP_I32_TO_F64", offset);
         case OP_U32_TO_F64:

--- a/tests/errors/is_type_second_arg.orus
+++ b/tests/errors/is_type_second_arg.orus
@@ -1,0 +1,3 @@
+fn main() {
+    print(is_type(1, 2))
+}

--- a/tests/errors/type_no_args.orus
+++ b/tests/errors/type_no_args.orus
@@ -1,0 +1,3 @@
+fn main() {
+    print(type())
+}

--- a/tests/generics/identity_generic.orus
+++ b/tests/generics/identity_generic.orus
@@ -1,0 +1,8 @@
+fn id<T>(x: T) -> T {
+    return x
+}
+
+fn main() {
+    print(id(1))
+    print(id("hi"))
+}

--- a/tests/types/is_type_builtin.orus
+++ b/tests/types/is_type_builtin.orus
@@ -1,0 +1,5 @@
+fn main() {
+    print(is_type(1, "i32"))
+    print(is_type("hi", "string"))
+    print(is_type(1, "string"))
+}

--- a/tests/types/type_builtin.orus
+++ b/tests/types/type_builtin.orus
@@ -1,0 +1,6 @@
+fn main() {
+    print(type(1))
+    print(type("hi"))
+    let arr: [i32; 1] = [0]
+    print(type(arr))
+}


### PR DESCRIPTION
- add mapping from variable indices to function declarations
- store function types in `variableTypes`
- implement `substituteGenerics` and `instantiateStructType`
- mark function declarations for GC
- document that generic parameters are checked at compile time