### PR TITLE
Support vector printing and slicing

### DIFF
--- a/include/ast.h
+++ b/include/ast.h
@@ -15,6 +15,7 @@ typedef enum {
     AST_CALL,
     AST_ARRAY,
     AST_ARRAY_SET,
+    AST_SLICE,
     AST_STRUCT_LITERAL,
     AST_FIELD,
     AST_FIELD_SET,
@@ -165,6 +166,10 @@ typedef struct ASTNode {
         struct {
             struct ASTNode* index;
         } arraySet;
+        struct {
+            struct ASTNode* start;
+            struct ASTNode* end;
+        } slice;
         FieldAccessData fieldSet;
         FunctionData function;
         CallData call;
@@ -195,6 +200,7 @@ ASTNode* createTryNode(ASTNode* tryBlock, Token errorName, ASTNode* catchBlock);
 ASTNode* createReturnNode(ASTNode* value);
 ASTNode* createArrayNode(ASTNode* elements, int elementCount);
 ASTNode* createArraySetNode(ASTNode* array, ASTNode* index, ASTNode* value);
+ASTNode* createSliceNode(ASTNode* array, ASTNode* start, ASTNode* end);
 ASTNode* createStructLiteralNode(Token name, ASTNode* values, int fieldCount,
                                  Type** genericArgs, int genericArgCount);
 ASTNode* createFieldAccessNode(ASTNode* object, Token name);

--- a/include/chunk.h
+++ b/include/chunk.h
@@ -61,6 +61,7 @@ typedef enum {
     OP_U32_TO_STRING,
     OP_F64_TO_STRING,
     OP_BOOL_TO_STRING,
+    OP_ARRAY_TO_STRING,
     OP_CONCAT,
 
     // Logical operators
@@ -100,6 +101,7 @@ typedef enum {
     OP_ARRAY_POP,
     OP_LEN,
     OP_SUBSTRING,
+    OP_SLICE,
 } opCode;
 
 typedef struct {

--- a/src/compiler/ast.c
+++ b/src/compiler/ast.c
@@ -235,6 +235,18 @@ ASTNode* createArraySetNode(ASTNode* array, ASTNode* index, ASTNode* value) {
     return node;
 }
 
+ASTNode* createSliceNode(ASTNode* array, ASTNode* start, ASTNode* end) {
+    ASTNode* node = allocateASTNode();
+    node->type = AST_SLICE;
+    node->left = array;
+    node->right = NULL;
+    node->next = NULL;
+    node->data.slice.start = start;
+    node->data.slice.end = end;
+    node->valueType = NULL;
+    return node;
+}
+
 ASTNode* createStructLiteralNode(Token name, ASTNode* values, int fieldCount,
                                  Type** genericArgs, int genericArgCount) {
     ASTNode* node = allocateASTNode();

--- a/src/scanner/scanner.c
+++ b/src/scanner/scanner.c
@@ -261,6 +261,11 @@ static Token number() {
         }
     }
 
+    // Optional unsigned suffix
+    if (peek() == 'u' || peek() == 'U') {
+        advance();
+    }
+
     // Number contains underscores, which is allowed
 
     return make_token(TOKEN_NUMBER);

--- a/src/vm/debug.c
+++ b/src/vm/debug.c
@@ -160,6 +160,8 @@ int disassembleInstruction(Chunk* chunk, int offset) {
             return simpleInstruction("OP_LEN", offset);
         case OP_SUBSTRING:
             return simpleInstruction("OP_SUBSTRING", offset);
+        case OP_SLICE:
+            return simpleInstruction("OP_SLICE", offset);
 
         case OP_CALL: {
             uint8_t functionIndex = chunk->code[offset + 1];
@@ -187,6 +189,8 @@ int disassembleInstruction(Chunk* chunk, int offset) {
             return simpleInstruction("OP_F64_TO_STRING", offset);
         case OP_BOOL_TO_STRING:
             return simpleInstruction("OP_BOOL_TO_STRING", offset);
+        case OP_ARRAY_TO_STRING:
+            return simpleInstruction("OP_ARRAY_TO_STRING", offset);
         case OP_CONCAT:
             return simpleInstruction("OP_CONCAT", offset);
 


### PR DESCRIPTION
## Summary
- allow arrays and structs in string concatenation
- implement array slicing syntax and VM opcode
- accept unsigned integer literals with `u` suffix
- update VM, parser, compiler and scanner accordingly

## Testing
- `bash tests/run_all_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_684424ffa2a8832594db9598b1246242