### PR TITLE
Rename type builtin to type_of

### DIFF
--- a/src/compiler/compiler.c
+++ b/src/compiler/compiler.c
@@ -801,9 +801,9 @@ static void typeCheckNode(Compiler* compiler, ASTNode* node) {
                 }
                 node->valueType = getPrimitiveType(TYPE_STRING);
                 break;
-            } else if (tokenEquals(node->data.call.name, "type")) {
+            } else if (tokenEquals(node->data.call.name, "type_of")) {
                 if (node->data.call.argCount != 1) {
-                    error(compiler, "type() takes exactly one argument.");
+                    error(compiler, "type_of() takes exactly one argument.");
                     return;
                 }
                 ASTNode* valArg = node->data.call.arguments;

--- a/src/vm/vm.c
+++ b/src/vm/vm.c
@@ -24,7 +24,7 @@ static Value native_len(int argCount, Value* args);
 static Value native_substring(int argCount, Value* args);
 static Value native_push(int argCount, Value* args);
 static Value native_pop(int argCount, Value* args);
-static Value native_type(int argCount, Value* args);
+static Value native_type_of(int argCount, Value* args);
 static Value native_is_type(int argCount, Value* args);
 
 static InterpretResult run();
@@ -62,7 +62,7 @@ void initVM() {
     defineNative("substring", native_substring, 3, getPrimitiveType(TYPE_STRING));
     defineNative("push", native_push, 2, NULL);
     defineNative("pop", native_pop, 1, NULL);
-    defineNative("type", native_type, 1, getPrimitiveType(TYPE_STRING));
+    defineNative("type_of", native_type_of, 1, getPrimitiveType(TYPE_STRING));
     defineNative("is_type", native_is_type, 2, getPrimitiveType(TYPE_BOOL));
 }
 
@@ -275,9 +275,9 @@ static const char* getValueTypeName(Value val) {
     }
 }
 
-static Value native_type(int argCount, Value* args) {
+static Value native_type_of(int argCount, Value* args) {
     if (argCount != 1) {
-        RUNTIME_ERROR("type() takes exactly one argument.");
+        RUNTIME_ERROR("type_of() takes exactly one argument.");
         return NIL_VAL;
     }
     const char* name = getValueTypeName(args[0]);

--- a/tests/errors/type_no_args.orus
+++ b/tests/errors/type_no_args.orus
@@ -1,3 +1,3 @@
 fn main() {
-    print(type())
+    print(type_of())
 }

--- a/tests/generics/comprehensive_generic_test.orus
+++ b/tests/generics/comprehensive_generic_test.orus
@@ -3,10 +3,10 @@
 
 // Generic helper functions must be defined before use in Orus.
 fn toString<T>(value: T) -> string {
-    if (type(value) == "string") {
+    if (type_of(value) == "string") {
         return value
     }
-    return "<" + type(value) + ">"
+    return "<" + type_of(value) + ">"
 }
 
 fn error(msg: string) {

--- a/tests/types/type_builtin.orus
+++ b/tests/types/type_builtin.orus
@@ -1,6 +1,6 @@
 fn main() {
-    print(type(1))
-    print(type("hi"))
+    print(type_of(1))
+    print(type_of("hi"))
     let arr: [i32; 1] = [0]
-    print(type(arr))
+    print(type_of(arr))
 }


### PR DESCRIPTION
## Summary
- rename the `type` builtin to `type_of`
- update compiler and VM implementations
- adjust tests for the new builtin name

## Testing
- `make orus`
- `bash tests/run_all_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68446c03e7d8832587ced7408bd5574a