### PR TITLE
Fix runtime error output

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -13,8 +13,12 @@
 #include "../include/version.h"
 
 static void printError(ObjError* err) {
-    fprintf(stderr, "%s:%d:%d: %s\n", err->location.file, err->location.line,
-            err->location.column, err->message->chars);
+    if (err->location.file) {
+        fprintf(stderr, "%s:%d:%d: %s\n", err->location.file, err->location.line,
+                err->location.column, err->message->chars);
+    } else {
+        fprintf(stderr, "%s\n", err->message->chars);
+    }
     vmPrintStackTrace();
 }
 

--- a/src/vm/vm.c
+++ b/src/vm/vm.c
@@ -91,20 +91,20 @@ static void printStackTrace() {
 
 void vmPrintStackTrace(void) { printStackTrace(); }
 
-static void runtimeError(ErrorType type, SrcLocation location, const char* format, ...) {
+static void runtimeError(ErrorType type, SrcLocation location,
+                         const char* format, ...) {
     char buffer[256];
     va_list args;
     va_start(args, format);
     vsnprintf(buffer, sizeof(buffer), format, args);
     va_end(args);
-    fprintf(stderr, "%s:%d:%d: %s\n", location.file, location.line, location.column, buffer);
-    printStackTrace();
+
     ObjError* err = allocateError(type, buffer, location);
     vm.lastError = ERROR_VAL(err);
 }
 
 #define RUNTIME_ERROR(fmt, ...) \
-    runtimeError(ERROR_RUNTIME, (SrcLocation){__FILE__, __LINE__, 0}, fmt, ##__VA_ARGS__)
+    runtimeError(ERROR_RUNTIME, (SrcLocation){NULL, 0, 0}, fmt, ##__VA_ARGS__)
 
 static bool appendStringDynamic(const char* src, char** buffer,
                                 int* length, int* capacity) {


### PR DESCRIPTION
## Summary
- avoid printing internal VM file locations in runtime error messages
- print simple error message if no location is available