### PR TITLE
Allow multiline expressions across newline tokens

### DIFF
--- a/include/parser.h
+++ b/include/parser.h
@@ -29,6 +29,7 @@ typedef struct {
     ObjString** genericParams;
     int genericCount;
     int genericCapacity;
+    int parenDepth;
 } Parser;
 
 typedef ASTNode* (*ParseFn)(Parser*);


### PR DESCRIPTION
## Summary
- extend `Parser` with `parenDepth` tracker
- ignore newline tokens after operators or inside parens
- parse precedence now skips internal newlines safely