### PR TITLE
Improve compiler error diagnostics

### DIFF
--- a/include/error.h
+++ b/include/error.h
@@ -31,6 +31,7 @@ typedef enum {
     ERROR_IMMUTABLE_ASSIGNMENT = 594,  // E0594
     ERROR_SCOPE_ERROR        = 426,    // E0426
     ERROR_FUNCTION_CALL      =  61,    // E0061
+    ERROR_GENERAL            =   2,    // E0002
     ERROR_PARSE                = 1,    // E0001
 } ErrorCode;
 
@@ -94,6 +95,9 @@ void emitIsTypeSecondArgError(Compiler* compiler, Token* token, const char* actu
 void emitLenInvalidTypeError(Compiler* compiler, Token* token, const char* actualType);
 void emitBuiltinArgCountError(Compiler* compiler, Token* token,
                               const char* name, int expected, int actual);
+
+// Emit a simple compiler error with no specific span information.
+void emitSimpleError(Compiler* compiler, ErrorCode code, const char* message);
 
 void emitDiagnostic(Diagnostic* diagnostic);
 

--- a/src/compiler/compiler.c
+++ b/src/compiler/compiler.c
@@ -90,22 +90,16 @@ static void endScope(Compiler* compiler) {
 }
 
 static void error(Compiler* compiler, const char* message) {
-    if (compiler->panicMode) return;
-    compiler->panicMode = true;
-    fprintf(stderr, "Compiler Error: %s\n", message);
-    compiler->hadError = true;
+    emitSimpleError(compiler, ERROR_GENERAL, message);
 }
 
 static void errorFmt(Compiler* compiler, const char* format, ...) {
-    if (compiler->panicMode) return;
-    compiler->panicMode = true;
     char buffer[256];
     va_list args;
     va_start(args, format);
     vsnprintf(buffer, sizeof(buffer), format, args);
     va_end(args);
-    fprintf(stderr, "Compiler Error: %s\n", buffer);
-    compiler->hadError = true;
+    emitSimpleError(compiler, ERROR_GENERAL, buffer);
 }
 
 
@@ -153,6 +147,8 @@ static void typeCheckNode(Compiler* compiler, ASTNode* node) {
     if (!node) {
         return;
     }
+
+    compiler->currentLine = node->line;
 
     switch (node->type) {
         case AST_LITERAL: {

--- a/src/compiler/error.c
+++ b/src/compiler/error.c
@@ -546,3 +546,22 @@ void emitBuiltinArgCountError(Compiler* compiler, Token* token,
     compiler->hadError = true;
 }
 
+// Emit a simple compiler error when no detailed context is available.
+void emitSimpleError(Compiler* compiler, ErrorCode code, const char* message) {
+    if (compiler->panicMode) return;
+    compiler->panicMode = true;
+
+    Diagnostic diagnostic;
+    memset(&diagnostic, 0, sizeof(Diagnostic));
+
+    diagnostic.code = code;
+    diagnostic.text.message = message;
+    diagnostic.primarySpan.filePath = compiler->filePath;
+    diagnostic.primarySpan.line = compiler->currentLine > 0 ? compiler->currentLine : 1;
+    diagnostic.primarySpan.column = 1;
+    diagnostic.primarySpan.length = 1;
+
+    emitDiagnostic(&diagnostic);
+    compiler->hadError = true;
+}
+


### PR DESCRIPTION
## Summary
- add a general diagnostic code
- provide `emitSimpleError` helper
- use new helper in the compiler and record line information

## Testing
- `make orus`
- `tests/run_all_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_684579f3cee483259b411effff1ae808