### PR TITLE
Fix diagnostic caret positioning

### DIFF
--- a/include/chunk.h
+++ b/include/chunk.h
@@ -106,6 +106,7 @@ typedef enum {
 
 typedef struct {
     int line;
+    int column;
     int run_length;
 } LineInfo;
 
@@ -128,11 +129,12 @@ typedef struct {
 
 void initChunk(Chunk* chunk);
 void freeChunk(Chunk* chunk);
-void writeChunk(Chunk* chunk, uint8_t byte, int line);
+void writeChunk(Chunk* chunk, uint8_t byte, int line, int column);
 int addConstant(Chunk* Chunk, Value value);
-void writeConstant(Chunk* chunk, Value value, int line);
+void writeConstant(Chunk* chunk, Value value, int line, int column);
 int len(Chunk* chunk);
 int get_line(Chunk* chunk, int offset);
+int get_column(Chunk* chunk, int offset);
 uint8_t get_code(Chunk* chunk, int offset);
 Value get_constant(Chunk* chunk, int offset);
 

--- a/include/compiler.h
+++ b/include/compiler.h
@@ -34,8 +34,9 @@ typedef struct {
     const char** lineStarts;
     int lineCount;
 
-    // Line number of the AST node currently being compiled
+    // Line/column of the AST node currently being compiled
     int currentLine;
+    int currentColumn;
 } Compiler;
 
 void initCompiler(Compiler* compiler, Chunk* chunk,

--- a/include/error.h
+++ b/include/error.h
@@ -99,6 +99,12 @@ void emitBuiltinArgCountError(Compiler* compiler, Token* token,
 // Emit a simple compiler error with no specific span information.
 void emitSimpleError(Compiler* compiler, ErrorCode code, const char* message);
 
+// Emit an error anchored at a specific token location.
+void emitTokenError(Compiler* compiler,
+                    Token* token,
+                    ErrorCode code,
+                    const char* message);
+
 void emitDiagnostic(Diagnostic* diagnostic);
 
 #endif // ORUS_ERROR_H

--- a/include/vm.h
+++ b/include/vm.h
@@ -59,6 +59,7 @@ typedef struct {
     // Path of the file currently being executed. Used for runtime diagnostics.
     const char* filePath;
     int currentLine;
+    int currentColumn;
 
     Function functions[UINT8_COUNT];
     uint16_t functionCount;


### PR DESCRIPTION
## Summary
- add `emitTokenError` utility
- use `emitTokenError` when reporting unknown fields, bad indexing, and type mismatches
- expose new helper in the public header
- track column information in the VM so runtime errors can highlight the exact location

## Testing
- `make orus`
- `./orus tests/errors/undefined_field.orus`
- `./orus tests/errors/array_index_type.orus`
- `./orus tests/builtins/errors/int_invalid.orus`
- `./orus tests/builtins/errors/print_extra_args.orus`


------
https://chatgpt.com/codex/tasks/task_e_684581e42cec83259221cd67aa238303