### PR TITLE
Improve error classification in diagnostics

### DIFF
--- a/src/compiler/error.c
+++ b/src/compiler/error.c
@@ -29,8 +29,18 @@ static const char* getSourceLine(const char* filePath, int lineNum) {
 
 void emitDiagnostic(Diagnostic* diagnostic) {
     // 1. Header with error code and message
-    printf("%sError[E%04d]%s: %s\n",
-           COLOR_RED, diagnostic->code, COLOR_RESET,
+    const char* category = "Compile error";
+    if (diagnostic->code == (ErrorCode)ERROR_RUNTIME) {
+        category = "Runtime error";
+    } else if (diagnostic->code == (ErrorCode)ERROR_TYPE &&
+               diagnostic->code != ERROR_PARSE) {
+        category = "Runtime type error";
+    } else if (diagnostic->code == (ErrorCode)ERROR_IO) {
+        category = "Runtime I/O error";
+    }
+
+    printf("%s%s [E%04d]%s: %s\n",
+           COLOR_RED, category, diagnostic->code, COLOR_RESET,
            diagnostic->text.message);
 
     // 2. File location

--- a/src/main.c
+++ b/src/main.c
@@ -15,7 +15,7 @@
 static void printError(ObjError* err) {
     Diagnostic diag;
     memset(&diag, 0, sizeof(Diagnostic));
-    diag.code = (ErrorCode)ERROR_RUNTIME;
+    diag.code = (ErrorCode)err->type;
     diag.text.message = err->message->chars;
     diag.primarySpan.filePath = err->location.file ? err->location.file : "<runtime>";
     diag.primarySpan.line = err->location.line;


### PR DESCRIPTION
## Summary
- classify diagnostic output as runtime or compile errors
- propagate runtime error type in `printError`