### PR TITLE
Improve print/input argument error message

### DIFF
--- a/src/parser/parser.c
+++ b/src/parser/parser.c
@@ -309,7 +309,7 @@ static ASTNode* parseCall(Parser* parser, ASTNode* left) {
                 if (firstArgNeedsString && argStart.type != TOKEN_STRING) {
                     char msg[128];
                     snprintf(msg, sizeof(msg),
-                             "%.*s() expects a string as the first argument",
+                             "%.*s() expects a string argument",
                              name.length, name.start);
                     errorAt(parser, &argStart, msg);
                     if (parser->hadError) return NULL;


### PR DESCRIPTION
## Summary
- clarify builtin argument error wording

## Testing
- `make`
- `bash tests/run_all_tests.sh` *(fails: generic_forward_declaration.orus)*

------
https://chatgpt.com/codex/tasks/task_e_68458ffc83e483258399ab15c9d0c244