### PR TITLE
Add sum builtin

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ include:
 - Static type annotations for integers (`i32`/`u32`), floating point numbers
   (`f64`), booleans and strings with local type inference using `let`.
 - Arrays with fixed lengths (including multidimensional arrays) and
-  dynamic arrays using `push`, `pop` and `len`.
+  dynamic arrays using `push`, `pop`, `len` and `sum`.
 - User defined `struct` types and `impl` blocks for instance or static methods.
 - Generic functions and structs with type parameters.
 - Modules and `import` statements for splitting code across files.

--- a/docs/BUILTINS.md
+++ b/docs/BUILTINS.md
@@ -13,6 +13,7 @@ description.
 | `push(array, value)` | Append a value to a dynamic array. |
 | `pop(array)` | Remove and return the last element of an array. |
 | `range(start, end)` | Return an array of integers from `start` (inclusive) to `end` (exclusive). |
+| `sum(array)` | Sum all numeric elements of an array.
 | `type_of(value)` | Return the name of a value's type as a string. |
 | `is_type(value, name)` | Check whether a value is of the given type. |
 | `input(prompt)` | Display a prompt and return a line of user input. |

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -443,6 +443,7 @@ For a complete list see [BUILTINS.md](BUILTINS.md).
 - `push(array, value)` – Append a value to a dynamic array.
 - `pop(array)` – Remove and return the last element of an array.
 - `range(start, end)` – Generate a sequence of integers for `for` loops.
+- `sum(array)` – Sum all numeric elements of an array.
 - `type_of(value)` – Return the name of a value's type as a string.
 - `is_type(value, name)` – Check whether a value is of the given type.
 - `input(prompt)` – Display a prompt and return a line of user input.

--- a/src/compiler/compiler.c
+++ b/src/compiler/compiler.c
@@ -1018,6 +1018,20 @@ static void typeCheckNode(Compiler* compiler, ASTNode* node) {
             }
 
             if (index == UINT8_MAX) {
+                if (node->data.call.nativeIndex != -1 && tokenEquals(node->data.call.name, "sum")) {
+                    ASTNode* arr = node->data.call.arguments;
+                    if (!arr->valueType || arr->valueType->kind != TYPE_ARRAY) {
+                        error(compiler, "sum() expects array.");
+                        return;
+                    }
+                    Type* elem = arr->valueType->info.array.elementType;
+                    if (elem->kind != TYPE_I32 && elem->kind != TYPE_U32 && elem->kind != TYPE_F64) {
+                        error(compiler, "sum() array must contain numbers.");
+                        return;
+                    }
+                    node->valueType = elem;
+                    break;
+                }
                 emitUndefinedFunctionError(compiler, &node->data.call.name);
                 return;
             }

--- a/src/vm/builtins.c
+++ b/src/vm/builtins.c
@@ -205,6 +205,38 @@ static Value native_float(int argCount, Value* args) {
     return F64_VAL(value);
 }
 
+static Value native_sum(int argCount, Value* args) {
+    if (argCount != 1) {
+        vmRuntimeError("sum() takes exactly one argument.");
+        return NIL_VAL;
+    }
+    if (!IS_ARRAY(args[0])) {
+        vmRuntimeError("sum() expects array.");
+        return NIL_VAL;
+    }
+    ObjArray* arr = AS_ARRAY(args[0]);
+    double total = 0;
+    bool asFloat = false;
+    for (int i = 0; i < arr->length; i++) {
+        Value v = arr->elements[i];
+        if (IS_I32(v)) {
+            total += AS_I32(v);
+        } else if (IS_U32(v)) {
+            total += AS_U32(v);
+        } else if (IS_F64(v)) {
+            total += AS_F64(v);
+            asFloat = true;
+        } else {
+            vmRuntimeError("sum() array must contain only numbers.");
+            return NIL_VAL;
+        }
+    }
+    if (asFloat)
+        return F64_VAL(total);
+    else
+        return I32_VAL((int32_t)total);
+}
+
 typedef struct {
     const char* name;
     NativeFn fn;
@@ -218,6 +250,7 @@ static BuiltinEntry builtinTable[] = {
     {"push", native_push, 2, TYPE_COUNT},
     {"pop", native_pop, 1, TYPE_COUNT},
     {"range", native_range, 2, TYPE_COUNT},
+    {"sum", native_sum, 1, TYPE_COUNT},
     {"type_of", native_type_of, 1, TYPE_STRING},
     {"is_type", native_is_type, 2, TYPE_BOOL},
     {"input", native_input, 1, TYPE_STRING},

--- a/tests/builtins/sum_complex.orus
+++ b/tests/builtins/sum_complex.orus
@@ -1,0 +1,10 @@
+fn main() {
+    let values: [f64] = [1.5, 2.5, 3.0]
+    print(sum(values))
+
+    let arr: [i32; 1] = [0]
+    push(arr, 10)
+    push(arr, 20)
+    push(arr, -5)
+    print(sum(arr))
+}

--- a/tests/builtins/sum_simple.orus
+++ b/tests/builtins/sum_simple.orus
@@ -1,0 +1,4 @@
+fn main() {
+    let nums = [1, 2, 3, 4]
+    print(sum(nums))
+}


### PR DESCRIPTION
## Summary
- implement `sum` builtin in `builtins.c`
- allow compiler to resolve `sum` when not defined as a regular function
- document `sum` in README, BUILTINS.md and LANGUAGE.md
- add simple and complex tests for `sum`