### PR TITLE
Add min/max builtins

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ include:
 - Static type annotations for integers (`i32`/`u32`), floating point numbers
   (`f64`), booleans and strings with local type inference using `let`.
 - Arrays with fixed lengths (including multidimensional arrays) and
-  dynamic arrays using `push`, `pop`, `len` and `sum`.
+  dynamic arrays using `push`, `pop`, `len`, `sum`, `min` and `max`.
 - User defined `struct` types and `impl` blocks for instance or static methods.
 - Generic functions and structs with type parameters.
 - Modules and `import` statements for splitting code across files.

--- a/docs/BUILTINS.md
+++ b/docs/BUILTINS.md
@@ -14,6 +14,8 @@ description.
 | `pop(array)` | Remove and return the last element of an array. |
 | `range(start, end)` | Return an array of integers from `start` (inclusive) to `end` (exclusive). |
 | `sum(array)` | Sum all numeric elements of an array.
+| `min(array)` | Return the smallest numeric element of an array.
+| `max(array)` | Return the largest numeric element of an array.
 | `type_of(value)` | Return the name of a value's type as a string. |
 | `is_type(value, name)` | Check whether a value is of the given type. |
 | `input(prompt)` | Display a prompt and return a line of user input. |

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -444,6 +444,8 @@ For a complete list see [BUILTINS.md](BUILTINS.md).
 - `pop(array)` – Remove and return the last element of an array.
 - `range(start, end)` – Generate a sequence of integers for `for` loops.
 - `sum(array)` – Sum all numeric elements of an array.
+- `min(array)` – Return the smallest numeric element of an array.
+- `max(array)` – Return the largest numeric element of an array.
 - `type_of(value)` – Return the name of a value's type as a string.
 - `is_type(value, name)` – Check whether a value is of the given type.
 - `input(prompt)` – Display a prompt and return a line of user input.

--- a/src/vm/builtins.c
+++ b/src/vm/builtins.c
@@ -237,6 +237,106 @@ static Value native_sum(int argCount, Value* args) {
         return I32_VAL((int32_t)total);
 }
 
+static Value native_min(int argCount, Value* args) {
+    if (argCount != 1) {
+        vmRuntimeError("min() takes exactly one argument.");
+        return NIL_VAL;
+    }
+    if (!IS_ARRAY(args[0])) {
+        vmRuntimeError("min() expects array.");
+        return NIL_VAL;
+    }
+    ObjArray* arr = AS_ARRAY(args[0]);
+    if (arr->length == 0) return NIL_VAL;
+
+    Value first = arr->elements[0];
+    double best;
+    bool asFloat = false;
+    if (IS_I32(first)) {
+        best = AS_I32(first);
+    } else if (IS_U32(first)) {
+        best = AS_U32(first);
+    } else if (IS_F64(first)) {
+        best = AS_F64(first);
+        asFloat = true;
+    } else {
+        vmRuntimeError("min() array must contain only numbers.");
+        return NIL_VAL;
+    }
+
+    for (int i = 1; i < arr->length; i++) {
+        Value v = arr->elements[i];
+        double val;
+        if (IS_I32(v)) {
+            val = AS_I32(v);
+        } else if (IS_U32(v)) {
+            val = AS_U32(v);
+        } else if (IS_F64(v)) {
+            val = AS_F64(v);
+            asFloat = true;
+        } else {
+            vmRuntimeError("min() array must contain only numbers.");
+            return NIL_VAL;
+        }
+        if (val < best) best = val;
+    }
+
+    if (asFloat)
+        return F64_VAL(best);
+    else
+        return I32_VAL((int32_t)best);
+}
+
+static Value native_max(int argCount, Value* args) {
+    if (argCount != 1) {
+        vmRuntimeError("max() takes exactly one argument.");
+        return NIL_VAL;
+    }
+    if (!IS_ARRAY(args[0])) {
+        vmRuntimeError("max() expects array.");
+        return NIL_VAL;
+    }
+    ObjArray* arr = AS_ARRAY(args[0]);
+    if (arr->length == 0) return NIL_VAL;
+
+    Value first = arr->elements[0];
+    double best;
+    bool asFloat = false;
+    if (IS_I32(first)) {
+        best = AS_I32(first);
+    } else if (IS_U32(first)) {
+        best = AS_U32(first);
+    } else if (IS_F64(first)) {
+        best = AS_F64(first);
+        asFloat = true;
+    } else {
+        vmRuntimeError("max() array must contain only numbers.");
+        return NIL_VAL;
+    }
+
+    for (int i = 1; i < arr->length; i++) {
+        Value v = arr->elements[i];
+        double val;
+        if (IS_I32(v)) {
+            val = AS_I32(v);
+        } else if (IS_U32(v)) {
+            val = AS_U32(v);
+        } else if (IS_F64(v)) {
+            val = AS_F64(v);
+            asFloat = true;
+        } else {
+            vmRuntimeError("max() array must contain only numbers.");
+            return NIL_VAL;
+        }
+        if (val > best) best = val;
+    }
+
+    if (asFloat)
+        return F64_VAL(best);
+    else
+        return I32_VAL((int32_t)best);
+}
+
 typedef struct {
     const char* name;
     NativeFn fn;
@@ -251,6 +351,8 @@ static BuiltinEntry builtinTable[] = {
     {"pop", native_pop, 1, TYPE_COUNT},
     {"range", native_range, 2, TYPE_COUNT},
     {"sum", native_sum, 1, TYPE_COUNT},
+    {"min", native_min, 1, TYPE_COUNT},
+    {"max", native_max, 1, TYPE_COUNT},
     {"type_of", native_type_of, 1, TYPE_STRING},
     {"is_type", native_is_type, 2, TYPE_BOOL},
     {"input", native_input, 1, TYPE_STRING},

--- a/tests/builtins/max_complex.orus
+++ b/tests/builtins/max_complex.orus
@@ -1,0 +1,10 @@
+fn main() {
+    let values: [f64] = [3.5, 2.0, 4.1]
+    print(max(values))
+
+    let arr: [i32; 1] = [0]
+    push(arr, 10)
+    push(arr, -3)
+    push(arr, 7)
+    print(max(arr))
+}

--- a/tests/builtins/max_simple.orus
+++ b/tests/builtins/max_simple.orus
@@ -1,0 +1,4 @@
+fn main() {
+    let nums = [3, 1, 5, 2]
+    print(max(nums))
+}

--- a/tests/builtins/min_complex.orus
+++ b/tests/builtins/min_complex.orus
@@ -1,0 +1,10 @@
+fn main() {
+    let values: [f64] = [3.5, 2.0, 4.1]
+    print(min(values))
+
+    let arr: [i32; 1] = [0]
+    push(arr, 10)
+    push(arr, -3)
+    push(arr, 7)
+    print(min(arr))
+}

--- a/tests/builtins/min_simple.orus
+++ b/tests/builtins/min_simple.orus
@@ -1,0 +1,4 @@
+fn main() {
+    let nums = [3, 1, 5, 2]
+    print(min(nums))
+}


### PR DESCRIPTION
## Summary
- implement `min()` and `max()` builtins
- support returning smallest or largest array element
- allow user-defined functions named `min`/`max`
- document new builtins in README and docs
- add tests for simple and complex usages