### PR TITLE
Document optional key argument for sorted

### DIFF
--- a/docs/BUILTINS.md
+++ b/docs/BUILTINS.md
@@ -21,7 +21,7 @@ description.
 | `input(prompt)` | Display a prompt and return a line of user input. |
 | `int(text)` | Convert a string to an `i32`, raising an error on failure. |
 | `float(text)` | Convert a string to an `f64`, raising an error on failure. |
-| `sorted(array, key, reverse)` | Return a new array with the elements sorted. |
+| `sorted(array, key, reverse)` | Return a new array with the elements sorted. The `key` and `reverse` arguments are optional. |
 
 ### `sorted`
 
@@ -29,17 +29,18 @@ The `sorted()` builtin takes an array of numbers or strings and returns a new
 array containing the elements in order. The original array is left unchanged.
 
 ```
-sorted(array, nil, reverse)
+sorted(array, key=nil, reverse)
 ```
 
 * **array** – The values to sort. All elements must be numbers or strings.
-* **key** – Reserved for a future key function. It must be `nil` for now.
+* **key** – Optional. Reserved for a future key function. It must be `nil` if
+  provided.
 * **reverse** – Optional boolean. If `true`, the array is sorted in descending
   order. Defaults to ascending order when omitted.
 
 ```orus
 let data = [3, 1, 4, 1]
-print(sorted(data, nil, false))  // [1, 1, 3, 4]
+print(sorted(data))              // [1, 1, 3, 4]
 print(sorted(data, nil, true))   // [4, 3, 1, 1]
 ```
 

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -451,7 +451,7 @@ For a complete list see [BUILTINS.md](BUILTINS.md).
 - `input(prompt)` – Display a prompt and return a line of user input.
 - `int(text)` – Convert a string to an `i32`, raising an error on failure.
 - `float(text)` – Convert a string to an `f64`, raising an error on failure.
-- `sorted(array, key, reverse)` – Return a new array with the elements sorted.
+- `sorted(array, key, reverse)` – Return a new array with the elements sorted. The `key` and `reverse` arguments are optional.
 
 ```orus
 let arr: [i32; 1] = [1]
@@ -464,7 +464,7 @@ print("Hello, {}", name)
 let age: i32 = int(input("How old are you? "))
 let height: f64 = float(input("Height in meters? "))
 let nums = [4, 2, 1]
-print(sorted(nums, nil, false))
+print(sorted(nums))
 ```
 
 ## Error Handling


### PR DESCRIPTION
## Summary
- clarify in BUILTINS docs that `sorted` accepts optional `key` and `reverse`
- update `sorted` example and explanation in the language guide

## Testing
- `make`
- `bash tests/run_all_tests.sh` *(partial log shown as the full test run was interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_6846a86c01388325a8e460e42b4b838f