### PR TITLE
Allow omitting nil argument for sorted

### DIFF
--- a/docs/BUILTINS.md
+++ b/docs/BUILTINS.md
@@ -21,7 +21,7 @@ description.
 | `input(prompt)` | Display a prompt and return a line of user input. |
 | `int(text)` | Convert a string to an `i32`, raising an error on failure. |
 | `float(text)` | Convert a string to an `f64`, raising an error on failure. |
-| `sorted(array, key, reverse)` | Return a new array with the elements sorted. The `key` and `reverse` arguments are optional. |
+| `sorted(array, key, reverse)` | Return a new array with the elements sorted. The `key` argument is optional and reserved for future use. `reverse` may be passed as the second argument when no key is provided. |
 
 ### `sorted`
 
@@ -30,18 +30,20 @@ array containing the elements in order. The original array is left unchanged.
 
 ```
 sorted(array, key=nil, reverse)
+sorted(array, reverse)
 ```
 
 * **array** – The values to sort. All elements must be numbers or strings.
 * **key** – Optional. Reserved for a future key function. It must be `nil` if
   provided.
 * **reverse** – Optional boolean. If `true`, the array is sorted in descending
-  order. Defaults to ascending order when omitted.
+  order. Defaults to ascending order when omitted. This flag can be supplied
+  as the second argument if no key is given.
 
 ```orus
 let data = [3, 1, 4, 1]
-print(sorted(data))              // [1, 1, 3, 4]
-print(sorted(data, nil, true))   // [4, 3, 1, 1]
+print(sorted(data))        // [1, 1, 3, 4]
+print(sorted(data, true))  // [4, 3, 1, 1]
 ```
 
 

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -451,7 +451,7 @@ For a complete list see [BUILTINS.md](BUILTINS.md).
 - `input(prompt)` – Display a prompt and return a line of user input.
 - `int(text)` – Convert a string to an `i32`, raising an error on failure.
 - `float(text)` – Convert a string to an `f64`, raising an error on failure.
-- `sorted(array, key, reverse)` – Return a new array with the elements sorted. The `key` and `reverse` arguments are optional.
+- `sorted(array, key, reverse)` – Return a new array with the elements sorted. The `key` argument is optional and reserved for future use. `reverse` may be passed as the second argument when no key is supplied.
 
 ```orus
 let arr: [i32; 1] = [1]
@@ -465,6 +465,7 @@ let age: i32 = int(input("How old are you? "))
 let height: f64 = float(input("Height in meters? "))
 let nums = [4, 2, 1]
 print(sorted(nums))
+print(sorted(nums, true))
 ```
 
 ## Error Handling

--- a/src/compiler/compiler.c
+++ b/src/compiler/compiler.c
@@ -952,6 +952,7 @@ static void typeCheckNode(Compiler* compiler, ASTNode* node) {
                     error(compiler, "sorted() takes between 1 and 3 arguments.");
                     return;
                 }
+
                 ASTNode* arr = node->data.call.arguments;
                 typeCheckNode(compiler, arr);
                 if (compiler->hadError) return;
@@ -959,8 +960,21 @@ static void typeCheckNode(Compiler* compiler, ASTNode* node) {
                     error(compiler, "sorted() first argument must be array.");
                     return;
                 }
-                ASTNode* key = arr->next;
-                if (node->data.call.argCount >= 2) {
+
+                if (node->data.call.argCount == 2) {
+                    ASTNode* second = arr->next;
+                    typeCheckNode(compiler, second);
+                    if (compiler->hadError) return;
+                    if (!second->valueType) return; // safety
+                    if (second->valueType->kind == TYPE_BOOL) {
+                        // reverse flag only
+                    } else if (second->valueType->kind != TYPE_NIL) {
+                        error(compiler,
+                              "sorted() key function not supported yet.");
+                        return;
+                    }
+                } else if (node->data.call.argCount == 3) {
+                    ASTNode* key = arr->next;
                     typeCheckNode(compiler, key);
                     if (compiler->hadError) return;
                     if (!key->valueType || key->valueType->kind != TYPE_NIL) {
@@ -968,8 +982,7 @@ static void typeCheckNode(Compiler* compiler, ASTNode* node) {
                               "sorted() key function not supported yet.");
                         return;
                     }
-                }
-                if (node->data.call.argCount == 3) {
+
                     ASTNode* rev = key->next;
                     typeCheckNode(compiler, rev);
                     if (compiler->hadError) return;
@@ -978,6 +991,7 @@ static void typeCheckNode(Compiler* compiler, ASTNode* node) {
                         return;
                     }
                 }
+
                 node->valueType = arr->valueType;
                 break;
             }

--- a/src/vm/builtins.c
+++ b/src/vm/builtins.c
@@ -432,13 +432,20 @@ static Value native_sorted(int argCount, Value* args) {
         return NIL_VAL;
     }
 
-    if (argCount >= 2 && !IS_NIL(args[1])) {
-        vmRuntimeError("sorted() key function not supported yet.");
-        return NIL_VAL;
-    }
-
     bool reverse = false;
-    if (argCount == 3) {
+
+    if (argCount == 2) {
+        if (IS_BOOL(args[1])) {
+            reverse = AS_BOOL(args[1]);
+        } else if (!IS_NIL(args[1])) {
+            vmRuntimeError("sorted() key function not supported yet.");
+            return NIL_VAL;
+        }
+    } else if (argCount == 3) {
+        if (!IS_NIL(args[1])) {
+            vmRuntimeError("sorted() key function not supported yet.");
+            return NIL_VAL;
+        }
         if (!IS_BOOL(args[2])) {
             vmRuntimeError("sorted() third argument must be bool.");
             return NIL_VAL;

--- a/tests/builtins/sorted_basic.orus
+++ b/tests/builtins/sorted_basic.orus
@@ -1,5 +1,5 @@
 fn main() {
     let nums = [4, 2, 1, 3]
-    print(sorted(nums, nil, false))
-    print(sorted(nums, nil, true))
+    print(sorted(nums, false))
+    print(sorted(nums, true))
 }

--- a/tests/builtins/sorted_complex.orus
+++ b/tests/builtins/sorted_complex.orus
@@ -1,12 +1,12 @@
 fn main() {
     let nums = [5, 1, 4, 3, 2, 2]
-    print(sorted(nums, nil, false))
-    print(sorted(nums, nil, true))
+    print(sorted(nums, false))
+    print(sorted(nums, true))
 
     let words: [string; 1] = ["b"]
     push(words, "d")
     push(words, "a")
     push(words, "c")
-    print(sorted(words, nil, false))
-    print(sorted(words, nil, true))
+    print(sorted(words, false))
+    print(sorted(words, true))
 }


### PR DESCRIPTION
## Summary
- allow `sorted()` reverse flag without a placeholder nil
- update compiler checks for the new optional argument
- update builtins tests for the new behaviour
- document updated `sorted()` usage