### PR TITLE
Fix import syntax test

### DIFF
--- a/src/parser/parser.c
+++ b/src/parser/parser.c
@@ -977,6 +977,11 @@ static void returnStatement(Parser* parser, ASTNode** ast) {
 static void importStatement(Parser* parser, ASTNode** ast) {
     consume(parser, TOKEN_STRING, "Expect module path string after 'import'.");
     Token path = parser->previous;
+
+    // Emit an error recommending the new `use` statement syntax
+    errorAt(parser, &parser->previous,
+            "`import` statements are deprecated; use `use module::path` instead");
+
     consumeStatementEnd(parser);
     *ast = createImportNode(path);
     (*ast)->line = path.line;

--- a/tests/errors/import_deprecated.orus
+++ b/tests/errors/import_deprecated.orus
@@ -1,0 +1,3 @@
+import "tests/modules/hello_module.orus"
+
+fn main() {}

--- a/tests/modules/import_twice.orus
+++ b/tests/modules/import_twice.orus
@@ -1,5 +1,5 @@
-import "tests/modules/hello_module.orus"
-import "tests/modules/hello_module.orus"
+use tests::modules::hello_module
+use tests::modules::hello_module
 
 fn main() {
     print("done")


### PR DESCRIPTION
## Summary
- emit a diagnostic when using the old `import` statement
- add regression test for deprecated `import` syntax

## Testing
- `make`
- `bash tests/run_all_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_6846fe1add20832580d608e7816b5fe0