### PR TITLE
Implement module error handling and cycle checks

### DIFF
--- a/include/modules.h
+++ b/include/modules.h
@@ -30,6 +30,9 @@ bool register_module(Module* module);
 Module* get_module(const char* name);
 InterpretResult compile_module_only(const char* path);
 
+// Holds the last module loading error message if any
+extern const char* moduleError;
+
 // Ensure a module is loaded and executed. Returns INTERPRET_OK on success.
 InterpretResult interpret_module(const char* path);
 

--- a/tests/errors/import_cycle.orus
+++ b/tests/errors/import_cycle.orus
@@ -1,0 +1,4 @@
+use tests::modules::cycles::cycle_a
+
+fn main() {
+}

--- a/tests/errors/missing_export.orus
+++ b/tests/errors/missing_export.orus
@@ -1,0 +1,4 @@
+use tests::modules::hello_module::{unknown}
+
+fn main() {
+}

--- a/tests/modules/cycles/cycle_a.orus
+++ b/tests/modules/cycles/cycle_a.orus
@@ -1,0 +1,7 @@
+use tests::modules::cycles::cycle_b
+
+fn greet_a() {
+    print("Hello from A")
+}
+
+fn main() {}

--- a/tests/modules/cycles/cycle_b.orus
+++ b/tests/modules/cycles/cycle_b.orus
@@ -1,0 +1,7 @@
+use tests::modules::cycles::cycle_a
+
+fn greet_b() {
+    print("Hello from B")
+}
+
+fn main() {}


### PR DESCRIPTION
## Summary
- support module loading error reporting through `moduleError`
- detect import cycles when compiling or interpreting modules
- surface undefined module and missing export messages in compiler
- add runtime cycle detection in `interpretModule`
- create tests for missing export and import cycles

## Testing
- `make`
- `bash tests/run_all_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6847142368948325bece42f1eed30f84