### PR TITLE
Improve private access diagnostics

### DIFF
--- a/include/error.h
+++ b/include/error.h
@@ -31,6 +31,7 @@ typedef enum {
     ERROR_IMMUTABLE_ASSIGNMENT = 594,  // E0594
     ERROR_SCOPE_ERROR        = 426,    // E0426
     ERROR_FUNCTION_CALL      =  61,    // E0061
+    ERROR_PRIVATE_ACCESS     = 604,    // E0604
     ERROR_GENERAL            =   2,    // E0002
     ERROR_PARSE                = 1,    // E0001
 } ErrorCode;
@@ -89,6 +90,8 @@ void emitGenericTypeError(Compiler* compiler,
                          const char* help,
                          const char* note);
 void emitUndefinedFunctionError(Compiler* compiler, Token* token);
+void emitPrivateFunctionError(Compiler* compiler, Token* token);
+void emitPrivateVariableError(Compiler* compiler, Token* token);
 void emitStructFieldTypeMismatchError(Compiler* compiler, Token* token, const char* structName, const char* fieldName, const char* expectedType, const char* actualType);
 void emitFieldAccessNonStructError(Compiler* compiler, Token* token, const char* actualType);
 void emitIsTypeSecondArgError(Compiler* compiler, Token* token, const char* actualType);

--- a/src/compiler/error.c
+++ b/src/compiler/error.c
@@ -363,6 +363,64 @@ void emitUndefinedFunctionError(Compiler* compiler, Token* token) {
     compiler->hadError = true;
 }
 
+void emitPrivateFunctionError(Compiler* compiler, Token* token) {
+    if (compiler->panicMode) return;
+    compiler->panicMode = true;
+
+    Diagnostic diagnostic;
+    memset(&diagnostic, 0, sizeof(Diagnostic));
+
+    diagnostic.code = ERROR_PRIVATE_ACCESS;
+    diagnostic.primarySpan.line = token->line;
+    const char* lineStart = token->start;
+    while (lineStart > compiler->sourceCode && lineStart[-1] != '\n') lineStart--;
+    diagnostic.primarySpan.column = (int)(token->start - lineStart) + 1;
+    diagnostic.primarySpan.length = token->length;
+    diagnostic.primarySpan.filePath = compiler->filePath;
+
+    char msgBuffer[128];
+    snprintf(msgBuffer, sizeof(msgBuffer),
+             "function `%.*s` is private", token->length, token->start);
+    diagnostic.text.message = msgBuffer;
+    diagnostic.text.help = strdup("mark the function with `pub` to allow access from other modules");
+    const char* note = "only public items can be accessed from other modules";
+    diagnostic.text.notes = (char**)&note;
+    diagnostic.text.noteCount = 1;
+
+    emitDiagnostic(&diagnostic);
+    if (diagnostic.text.help) free(diagnostic.text.help);
+    compiler->hadError = true;
+}
+
+void emitPrivateVariableError(Compiler* compiler, Token* token) {
+    if (compiler->panicMode) return;
+    compiler->panicMode = true;
+
+    Diagnostic diagnostic;
+    memset(&diagnostic, 0, sizeof(Diagnostic));
+
+    diagnostic.code = ERROR_PRIVATE_ACCESS;
+    diagnostic.primarySpan.line = token->line;
+    const char* lineStart = token->start;
+    while (lineStart > compiler->sourceCode && lineStart[-1] != '\n') lineStart--;
+    diagnostic.primarySpan.column = (int)(token->start - lineStart) + 1;
+    diagnostic.primarySpan.length = token->length;
+    diagnostic.primarySpan.filePath = compiler->filePath;
+
+    char msgBuffer[128];
+    snprintf(msgBuffer, sizeof(msgBuffer),
+             "variable `%.*s` is private", token->length, token->start);
+    diagnostic.text.message = msgBuffer;
+    diagnostic.text.help = strdup("mark the variable with `pub` to allow access from other modules");
+    const char* note = "only public items can be accessed from other modules";
+    diagnostic.text.notes = (char**)&note;
+    diagnostic.text.noteCount = 1;
+
+    emitDiagnostic(&diagnostic);
+    if (diagnostic.text.help) free(diagnostic.text.help);
+    compiler->hadError = true;
+}
+
 void emitStructFieldTypeMismatchError(Compiler* compiler, Token* token, const char* structName, const char* fieldName, const char* expectedType, const char* actualType) {
     if (compiler->panicMode) return;
     compiler->panicMode = true;


### PR DESCRIPTION
## Summary
- add new ERROR_PRIVATE_ACCESS diagnostic
- report private access errors for functions and variables
- detect private globals when resolving calls or variables

## Testing
- `make`
- `bash tests/run_all_tests.sh`
- `./orus tests/errors/import_private.orus`

------
https://chatgpt.com/codex/tasks/task_e_6847208ac7008325b7d2ac88996e57b9