### PR TITLE
Add u32 variant of random generator

### DIFF
--- a/tests/algorithms/random_generation.orus
+++ b/tests/algorithms/random_generation.orus
@@ -1,0 +1,36 @@
+// Linear congruential generator example
+fn get_seed() -> [i32; 1] {
+    // Create once, reuse each time
+    let state: [i32; 1] = [123456789]
+    return state
+}
+
+// Generate the next pseudorandom i32 value
+fn rand_i32() -> i32 {
+    let state = get_seed()
+    let a: i32 = 1664525
+    let c: i32 = 1013904223
+    let next: i32 = a * state[0] + c
+    state[0] = next
+    return next
+}
+
+fn rand() -> f64 {
+    return rand_i32() / 4294967296.0
+}
+
+// Returns an integer in [min, max]
+fn rand_int(min: i32, max: i32) -> i32 {
+    let range: i32 = max - min + 1
+    return min + (rand_i32() % range)
+}
+
+fn main() {
+    print("Random float between 0 and 1: {}", rand())
+
+    let a = rand_int(1, 10)
+    let b = rand_int(1, 10)
+    let c = rand_int(1, 10)
+
+    print("Random ints between 1 and 10: {}, {}, {}", a, b, c)
+}

--- a/tests/algorithms/random_generation_u32.orus
+++ b/tests/algorithms/random_generation_u32.orus
@@ -1,0 +1,39 @@
+// Linear congruential generator example using u32 seed
+fn get_seed() -> [u32; 1] {
+    // Create once, reuse each time
+    let state: [u32; 1] = [123456789]
+    return state
+}
+
+// Generate the next pseudorandom u32 value
+fn rand_u32() -> u32 {
+    let state = get_seed()
+    let a: u32 = 1664525
+    let c: u32 = 1013904223
+    let next: u32 = a * state[0] + c
+    state[0] = next
+    return next
+}
+
+fn rand() -> f64 {
+    return rand_u32() / 4294967296.0
+}
+
+// Returns an unsigned integer in [min, max]
+fn rand_uint(min: u32, max: u32) -> u32 {
+    let range: u32 = max - min + 1
+    return min + (rand_u32() % range)
+}
+
+fn main() {
+    print("Random float between 0 and 1: {}", rand())
+
+    let min: u32 = 1
+    let max: u32 = 10
+
+    let a = rand_uint(min, max)
+    let b = rand_uint(min, max)
+    let c = rand_uint(min, max)
+
+    print("Random uints between 1 and 10: {}, {}, {}", a, b, c)
+}


### PR DESCRIPTION
## Summary
- add algorithms test using u32-based random generator
- support implicit conversion from i32 to u32 for array literals and addition
- avoid `u` suffix in new u32 random test

## Testing
- `make`
- `bash tests/run_all_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68472b7784708325bc233830282a3865