### PR TITLE
Add variable type persistence

### DIFF
--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -117,6 +117,7 @@ Variables are introduced with the `let` keyword and follow these rules:
 - All variables must be explicitly declared before use
 - Type annotations are optional when the type can be inferred
 - Variables can be reassigned with a compatible value
+- A variable's type is fixed after its declaration or first assignment
 - Variable scope is block-based
 - Variables cannot be declared outside functions
 - Variable names follow the common identifier rules (letters, digits, underscore; must start with letter/underscore)

--- a/src/compiler/compiler.c
+++ b/src/compiler/compiler.c
@@ -618,6 +618,31 @@ static void typeCheckNode(Compiler* compiler, ASTNode* node) {
                     valueType = varType;
                 }
             }
+
+            // Persist type if the variable was previously nil
+            if (varType->kind == TYPE_NIL && valueType->kind != TYPE_NIL) {
+                variableTypes[index] = valueType;
+                vm.globalTypes[index] = valueType;
+                char tempName[node->data.variable.name.length + 1];
+                memcpy(tempName, node->data.variable.name.start,
+                       node->data.variable.name.length);
+                tempName[node->data.variable.name.length] = '\0';
+                Symbol* sym = findSymbol(&compiler->symbols, tempName);
+                if (sym) sym->type = valueType;
+                varType = valueType;
+            } else if (varType->kind == TYPE_ARRAY &&
+                       varType->info.array.elementType->kind == TYPE_NIL &&
+                       valueType->kind == TYPE_ARRAY) {
+                variableTypes[index] = valueType;
+                vm.globalTypes[index] = valueType;
+                char tempName[node->data.variable.name.length + 1];
+                memcpy(tempName, node->data.variable.name.start,
+                       node->data.variable.name.length);
+                tempName[node->data.variable.name.length] = '\0';
+                Symbol* sym = findSymbol(&compiler->symbols, tempName);
+                if (sym) sym->type = valueType;
+                varType = valueType;
+            }
             // Allow i32/u32 literals to be used for f64 variables
             else if (varType->kind == TYPE_F64 &&
                     (valueType->kind == TYPE_I32 || valueType->kind == TYPE_U32) &&

--- a/src/vm/vm.c
+++ b/src/vm/vm.c
@@ -26,6 +26,20 @@ Type* variableTypes[UINT8_COUNT] = {NULL};
 static const char* runtimeStack[UINT8_COUNT];
 static uint8_t runtimeStackCount = 0;
 
+static bool checkValueAgainstType(Value value, Type* type) {
+    if (!type) return true;
+    switch (type->kind) {
+        case TYPE_I32: return IS_I32(value);
+        case TYPE_U32: return IS_U32(value);
+        case TYPE_F64: return IS_F64(value);
+        case TYPE_BOOL: return IS_BOOL(value);
+        case TYPE_STRING: return IS_STRING(value);
+        case TYPE_NIL: return IS_NIL(value);
+        case TYPE_ARRAY: return IS_ARRAY(value);
+        default: return true;
+    }
+}
+
 
 static InterpretResult run();
 
@@ -710,6 +724,12 @@ static InterpretResult run() {
                         }
                         
                     }
+                }
+
+                // Runtime type enforcement
+                if (!checkValueAgainstType(value, vm.globalTypes[index])) {
+                    RUNTIME_ERROR("Type mismatch for variable assignment.");
+                    return INTERPRET_RUNTIME_ERROR;
                 }
 
                 // Store the value in the global variable

--- a/tests/errors/type_persistence.orus
+++ b/tests/errors/type_persistence.orus
@@ -1,0 +1,5 @@
+fn main() {
+    let x = nil
+    x = 1
+    x = "oops"
+}

--- a/tests/variables/nil_inferred.orus
+++ b/tests/variables/nil_inferred.orus
@@ -1,0 +1,5 @@
+fn main() {
+    let x = nil
+    x = 42
+    print(x)
+}


### PR DESCRIPTION
## Summary
- enforce variable type after first assignment
- document type persistence in LANGUAGE.md
- runtime check for assignments
- tests for nil type inference and persistence