### PR TITLE
Enable implicit literal casting for typed vars

### DIFF
--- a/tests/algorithms/random_generation_u32.orus
+++ b/tests/algorithms/random_generation_u32.orus
@@ -1,7 +1,7 @@
 // Linear congruential generator example using u32 seed
 fn rand_u32(seed: [u32; 1]) -> u32 {
-    let a: u32 = 1664525 as u32
-    let c: u32 = 1013904223 as u32
+    let a: u32 = 1664525
+    let c: u32 = 1013904223
     let next: u32 = a * seed[0] + c
     seed[0] = next
     return next
@@ -18,12 +18,12 @@ fn rand_uint(seed: [u32; 1], min: u32, max: u32) -> u32 {
 }
 
 fn main() {
-    let seed: [u32; 1] = [123456789 as u32]
+    let seed: [u32; 1] = [123456789]
 
     print("Random float between 0 and 1: {}", rand(seed))
 
-    let min: u32 = 1 as u32
-    let max: u32 = 10 as u32
+    let min: u32 = 1
+    let max: u32 = 10
 
     let a = rand_uint(seed, min, max)
     let b = rand_uint(seed, min, max)

--- a/tests/builtins/type_builtin.orus
+++ b/tests/builtins/type_builtin.orus
@@ -1,5 +1,5 @@
 fn main() {
-    let a: u32 = 4 as u32
+    let a: u32 = 4
     print(type_of(a))
     print(type_of("hi"))
     let arr: [i32; 1] = [0]

--- a/tests/structs/rand.orus
+++ b/tests/structs/rand.orus
@@ -4,9 +4,9 @@ struct SeedBox {
 
 fn rand(store: [SeedBox; 1]) -> f64 {
 
-    let a: u32 = 1664525 as u32
-    let c: u32 = 1013904223 as u32
-    let m: u32 = 4294967295 as u32
+    let a: u32 = 1664525
+    let c: u32 = 1013904223
+    let m: u32 = 4294967295
 
     let current = store[0].value
     let next = (a * current + c) % m
@@ -26,7 +26,7 @@ fn rand_int(store: [SeedBox; 1], min: i32, max: i32) -> i32 {
 }
 
 fn main() {
-    let store: [SeedBox; 1] = [SeedBox{ value: 123456789 as u32 }]
+    let store: [SeedBox; 1] = [SeedBox{ value: 123456789 }]
 
     print("Random float: {}", rand(store))
 

--- a/tests/types/type_conversion.orus
+++ b/tests/types/type_conversion.orus
@@ -2,7 +2,7 @@
 
 fn main() {
     let i32_val: i32 = 42
-    let u32_val: u32 = 100 as u32
+    let u32_val: u32 = 100
     let f64_val: f64 = 3.14
 
     print("Type Conversion Test:")

--- a/tests/variables/declaration_test.orus
+++ b/tests/variables/declaration_test.orus
@@ -1,7 +1,7 @@
 // Tests variable declarations with different types
 fn main() {
     let i32_var: i32 = 42
-    let u32_var: u32 = 100 as u32
+    let u32_var: u32 = 100
     let f64_var: f64 = 3.14
     let bool_var: bool = true
     let inferred_i32 = 24


### PR DESCRIPTION
## Summary
- allow numeric literals to be implicitly converted when a variable has an explicit type
- update random number generator examples and other tests to remove redundant `as` casts