### PR TITLE
Update docs for pub functions

### DIFF
--- a/docs/ERROR_REFERENCE.md
+++ b/docs/ERROR_REFERENCE.md
@@ -28,6 +28,7 @@ The parser expects specific tokens at each point in the grammar. When a token do
 - `Expect '>' after generic arguments.`
 - `Expect ']' after array elements.`
 - `Expect field name.`
+  *Empty structs must be written with no newline between `{` and `}`:* `struct Foo {}`.
 - `Expect ':' after field name.`
 - `Expect '}' after struct literal.`
 - `Expect iterator variable name.`

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -250,6 +250,26 @@ use datetime as dt
 
 Modules are only loaded once. Importing the same file twice triggers a runtime error. Each module may define structs, functions and `impl` blocks. Only the entry file needs a `main` function.
 
+### Public functions
+
+Use the `pub` keyword before a top-level function to export it from a module. Only items marked `pub` can be imported with `use`.
+
+```orus
+// utils.orus
+pub fn helper() {
+    print("from helper")
+}
+
+// main.orus
+use utils::{helper}
+
+fn main() {
+    helper()
+}
+```
+
+Struct fields and methods cannot yet be declared `pub`.
+
 ## Built-in Functions
 
 Common utilities are always available. See `docs/BUILTINS.md` for full details.


### PR DESCRIPTION
## Summary
- document how to write empty structs
- document using `pub` to export functions in modules