### PR TITLE
Simplify module import semantics

### DIFF
--- a/docs/import.md
+++ b/docs/import.md
@@ -5,7 +5,8 @@ This roadmap outlines the detailed steps to make the `use` import system in Orus
 
 ## ✅ Goals
 
-* Support `use math`, `use random::{rand}`, `use datetime as dt`, etc.
+* Support `use math`, `use datetime as dt` style imports.
+* Modules are imported as a whole and referenced through the module name.
 * Ensure imported files execute once and expose usable functions, types, and constants.
 * Maintain a clean, professional structure aligned with the current codebase.
 
@@ -68,11 +69,9 @@ Module* get_module(const char* name);
 
   ```orus
   use math
-  use random::{rand, rand_int}
   use datetime as dt
   use tests::modules::hello_module
   use tests::modules::hello_module as hm
-  use tests::modules::hello_module::{greet}
   ```
 * Output an `ImportNode` in AST with:
 
@@ -104,13 +103,8 @@ Module* get_module(const char* name);
 
 ### Step 5: Bind Imports to Symbol Table ✅
 
-* When compiling the main file, inject the imported symbols into its scope.
-* If selective import: only bind those.
-
-  ```orus
-  use math::{clamp, round}  // Only these are exposed
-  use tests::modules::hello_module::{greet}
-  ```
+* When compiling the main file, register the module under its name or alias.
+* Access all public members through that module name.
 
 ### Step 6: Handle Aliasing
 
@@ -134,16 +128,16 @@ Module* get_module(const char* name);
 
 ---
 
-## ✅ Example Flow: `use math::{clamp}`
+## ✅ Example Flow: `use math`
 
-1. Parser reads and stores use statement
-2. Compiler resolves file path
+1. Parser reads and stores the `use` statement
+2. Compiler resolves the file path
 3. File content is read
 4. Parsed into AST
-5. Compiled to chunk
-6. Public symbols are registered in module export table
-7. `clamp` is added to the current file’s symbol table
-8. Later function calls to `clamp(...)` are resolved
+5. Compiled to bytecode
+6. Public symbols are registered in the module export table
+7. The module is bound under the name `math`
+8. Later calls use `math.clamp(...)`
 
 ---
 

--- a/include/symtable.h
+++ b/include/symtable.h
@@ -4,6 +4,7 @@
 #include "common.h"
 #include "type.h"
 #include "scanner.h"
+#include "modules.h"
 
 typedef struct {
     const char* name;
@@ -13,6 +14,8 @@ typedef struct {
     uint8_t index;
     bool active;
     bool isMutable;
+    bool isModule;           // True if this symbol represents a module alias
+    Module* module;          // Module associated with the alias
     Token token;
 } Symbol;
 
@@ -24,7 +27,9 @@ typedef struct {
 
 void initSymbolTable(SymbolTable* table);
 void freeSymbolTable(SymbolTable* table);
-bool addSymbol(SymbolTable* table, const char* name, Token token, Type* type, int scope, uint8_t index, bool isMutable);
+bool addSymbol(SymbolTable* table, const char* name, Token token, Type* type,
+               int scope, uint8_t index, bool isMutable,
+               bool isModule, Module* module);
 Symbol* findSymbol(SymbolTable* table, const char* name);
 Symbol* findAnySymbol(SymbolTable* table, const char* name);
 void removeSymbolsFromScope(SymbolTable* table, int scope);

--- a/src/compiler/symtable.c
+++ b/src/compiler/symtable.c
@@ -28,7 +28,9 @@ static void growCapacity(SymbolTable* table) {
     table->capacity = newCapacity;
 }
 
-bool addSymbol(SymbolTable* table, const char* name, Token token, Type* type, int scope, uint8_t index, bool isMutable) {
+bool addSymbol(SymbolTable* table, const char* name, Token token, Type* type,
+               int scope, uint8_t index, bool isMutable,
+               bool isModule, Module* module) {
     for (int i = 0; i < table->count; i++) {
         if (table->symbols[i].scope == scope && table->symbols[i].active &&
             strcmp(table->symbols[i].name, name) == 0) {
@@ -47,6 +49,8 @@ bool addSymbol(SymbolTable* table, const char* name, Token token, Type* type, in
     table->symbols[table->count].index = index;
     table->symbols[table->count].active = true;
     table->symbols[table->count].isMutable = isMutable;
+    table->symbols[table->count].isModule = isModule;
+    table->symbols[table->count].module = module;
     table->symbols[table->count].token = token;
     table->count++;
     

--- a/src/parser/parser.c
+++ b/src/parser/parser.c
@@ -1041,37 +1041,9 @@ static void useStatement(Parser* parser, ASTNode** ast) {
         consume(parser, TOKEN_IDENTIFIER, "Expect alias after 'as'.");
         alias = allocateString(parser->previous.start, parser->previous.length);
     } else if (match(parser, TOKEN_DOUBLE_COLON)) {
-        if (match(parser, TOKEN_STAR)) {
-            if (match(parser, TOKEN_AS)) {
-                consume(parser, TOKEN_IDENTIFIER, "Expect alias name.");
-                alias = allocateString(parser->previous.start, parser->previous.length);
-            }
-        } else if (match(parser, TOKEN_LEFT_BRACE)) {
-            if (!check(parser, TOKEN_RIGHT_BRACE)) {
-                do {
-                    consume(parser, TOKEN_IDENTIFIER, "Expect symbol name.");
-                    Token st = parser->previous;
-                    symbols = realloc(symbols, sizeof(ObjString*) * (symbolCount + 1));
-                    aliases = realloc(aliases, sizeof(ObjString*) * (symbolCount + 1));
-                    symbols[symbolCount] = allocateString(st.start, st.length);
-                    aliases[symbolCount] = NULL;
-                    symbolCount++;
-                } while (match(parser, TOKEN_COMMA));
-            }
-            consume(parser, TOKEN_RIGHT_BRACE, "Expect '}' after symbol list.");
-        } else {
-            consume(parser, TOKEN_IDENTIFIER, "Expect symbol name after '::'.");
-            Token st = parser->previous;
-            symbols = realloc(symbols, sizeof(ObjString*) * 1);
-            aliases = realloc(aliases, sizeof(ObjString*) * 1);
-            symbols[0] = allocateString(st.start, st.length);
-            aliases[0] = NULL;
-            symbolCount = 1;
-            if (match(parser, TOKEN_AS)) {
-                consume(parser, TOKEN_IDENTIFIER, "Expect alias name.");
-                aliases[0] = allocateString(parser->previous.start, parser->previous.length);
-            }
-        }
+        error(parser, "Only whole modules may be imported.");
+        // Consume the rest of the line for error recovery
+        while (!check(parser, TOKEN_NEWLINE) && !check(parser, TOKEN_EOF)) advance(parser);
     }
 
     // Build path string

--- a/tests/modules/parse_use_selective.orus
+++ b/tests/modules/parse_use_selective.orus
@@ -1,4 +1,4 @@
-use tests::modules::hello_module::{greet}
+use tests::modules::hello_module
 
 fn main() {
     print("select parsed")

--- a/tests/modules/use_bind.orus
+++ b/tests/modules/use_bind.orus
@@ -1,5 +1,5 @@
 use tests::modules::hello_module
 
 fn main() {
-    greet()
+    hello_module.greet()
 }

--- a/tests/modules/use_pub_function.orus
+++ b/tests/modules/use_pub_function.orus
@@ -1,6 +1,6 @@
-use tests::modules::pub_module::{public_fn}
+use tests::modules::pub_module
 
 fn main() {
-    public_fn()
+    pub_module.public_fn()
 }
 

--- a/tests/modules/use_selective.orus
+++ b/tests/modules/use_selective.orus
@@ -1,5 +1,5 @@
-use tests::modules::hello_module::{greet}
+use tests::modules::hello_module
 
 fn main() {
-    greet()
+    hello_module.greet()
 }


### PR DESCRIPTION
## Summary
- implement module-level import aliases
- support qualified module access in the type checker
- restrict parser to whole-module `use` statements
- update tests for the new module system
- document new behavior

## Testing
- `make`
- `bash tests/run_all_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6848201f0b9483259d2a0967d168cb2c