### PR TITLE
Enable newline for Orus print

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ include:
 - Function calls can reference functions defined later in the file.
 - Arithmetic, comparison and logical (`and`/`or`/`not`) operators.
 - String concatenation with `+` and a `print` function supporting simple
-  interpolation using `{}` placeholders. The `print` function behaves like
-  Rust's `print!` macro and does not append a newline automatically.
+  interpolation using `{}` placeholders. The `print` function automatically
+  appends a newline after the formatted output.
 - User input via `input(prompt)` for interactive programs.
 - Macro helpers for generic dynamic arrays.
 - Variables are immutable by default. Use `let mut` for reassignment.

--- a/docs/BUILTINS.md
+++ b/docs/BUILTINS.md
@@ -7,7 +7,7 @@ description.
 
 | Function | Description |
 |----------|-------------|
-| `print(values...)` | Output values to the console using `{}` placeholders for interpolation. No newline is appended, matching Rust's `print!` macro. |
+| `print(values...)` | Output values to the console using `{}` placeholders for interpolation. A newline is appended automatically. |
 | `len(value)` | Return the length of a string or array. |
 | `substring(str, start, len)` | Extract a portion of a string. |
 | `push(array, value)` | Append a value to a dynamic array. |

--- a/src/parser/parser.c
+++ b/src/parser/parser.c
@@ -1212,7 +1212,7 @@ static void statement(Parser* parser, ASTNode** ast) {
     bool newline = false;
     if (match(parser, TOKEN_PRINT)) {
         didPrint = true;
-        newline = false;
+        newline = true; // Always append a newline after print statements
     }
 
     if (didPrint) {


### PR DESCRIPTION
## Summary
- default `print` statements to include a newline
- document newline behaviour