### PR TITLE
Implement function return validation

### DIFF
--- a/include/compiler.h
+++ b/include/compiler.h
@@ -37,6 +37,8 @@ typedef struct {
     // Line/column of the AST node currently being compiled
     int currentLine;
     int currentColumn;
+    Type* currentReturnType;
+    bool currentFunctionHasGenerics;
 } Compiler;
 
 void initCompiler(Compiler* compiler, Chunk* chunk,

--- a/tests/errors/conditional_return_missing.orus
+++ b/tests/errors/conditional_return_missing.orus
@@ -1,0 +1,7 @@
+fn baz(x: bool) -> i32 {
+    if x {
+        return 1
+    }
+}
+
+fn main() {}

--- a/tests/errors/missing_return.orus
+++ b/tests/errors/missing_return.orus
@@ -1,0 +1,5 @@
+fn foo() -> i32 {
+    let a = 1
+}
+
+fn main() {}

--- a/tests/errors/return_type_mismatch.orus
+++ b/tests/errors/return_type_mismatch.orus
@@ -1,0 +1,5 @@
+fn bar() -> f64 {
+    return 3
+}
+
+fn main() {}

--- a/tests/errors/void_return_nonvoid.orus
+++ b/tests/errors/void_return_nonvoid.orus
@@ -1,0 +1,5 @@
+fn qux() -> string {
+    return
+}
+
+fn main() {}


### PR DESCRIPTION
## Summary
- detect missing returns or mismatched return types
- skip strict checks for generic functions
- track current function return type in compiler
- add comprehensive tests for new errors

## Testing
- `make orusc`
- `./tests/run_all_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_684ac41e98c08325b061f8b96c7ef538