### PR TITLE
Add i64 index support

### DIFF
--- a/include/chunk.h
+++ b/include/chunk.h
@@ -73,6 +73,7 @@ typedef enum {
     OP_U32_TO_I32,
     OP_I32_TO_I64,
     OP_U32_TO_I64,
+    OP_I64_TO_I32,
     OP_F64_TO_I32,
     OP_F64_TO_U32,
     OP_I32_TO_STRING,

--- a/src/compiler/compiler.c
+++ b/src/compiler/compiler.c
@@ -2283,6 +2283,8 @@ static void generateCode(Compiler* compiler, ASTNode* node) {
                 writeOp(compiler, OP_I32_TO_I64);
             } else if (from == TYPE_U32 && to == TYPE_I64) {
                 writeOp(compiler, OP_U32_TO_I64);
+            } else if (from == TYPE_I64 && to == TYPE_I32) {
+                writeOp(compiler, OP_I64_TO_I32);
             } else if (from == TYPE_F64 && to == TYPE_I32) {
                 writeOp(compiler, OP_F64_TO_I32);
             } else if (from == TYPE_F64 && to == TYPE_U32) {

--- a/src/vm/debug.c
+++ b/src/vm/debug.c
@@ -214,6 +214,8 @@ int disassembleInstruction(Chunk* chunk, int offset) {
             return simpleInstruction("OP_I32_TO_I64", offset);
         case OP_U32_TO_I64:
             return simpleInstruction("OP_U32_TO_I64", offset);
+        case OP_I64_TO_I32:
+            return simpleInstruction("OP_I64_TO_I32", offset);
         case OP_F64_TO_I32:
             return simpleInstruction("OP_F64_TO_I32", offset);
         case OP_F64_TO_U32:

--- a/src/vm/vm.c
+++ b/src/vm/vm.c
@@ -621,6 +621,15 @@ static InterpretResult run() {
                 vmPush(&vm, I64_VAL((int64_t)value));
                 break;
             }
+            case OP_I64_TO_I32: {
+                if (!IS_I64(vmPeek(&vm, 0))) {
+                    RUNTIME_ERROR("Operand must be an integer.");
+                    return INTERPRET_RUNTIME_ERROR;
+                }
+                int64_t value = AS_I64(vmPop(&vm));
+                vmPush(&vm, I32_VAL((int32_t)value));
+                break;
+            }
             case OP_F64_TO_I32: {
                 if (!IS_F64(vmPeek(&vm, 0))) {
                     RUNTIME_ERROR("Operand must be a floating point number.");

--- a/tests/algorithms/random_generation_i64.orus
+++ b/tests/algorithms/random_generation_i64.orus
@@ -1,0 +1,65 @@
+// Linear congruential generator example rewritten to use i64
+struct RNG {
+    seed: i64,
+}
+
+impl RNG {
+    fn new(seed: i64) -> RNG {
+        return RNG{ seed: seed }
+    }
+
+    fn next(self) -> i64 {
+        let multiplier: i64 = 1103515245
+        let increment: i64 = 12345
+        let modulus: i64 = 2147483648
+        self.seed = (self.seed * multiplier + increment) % modulus
+        return self.seed
+    }
+
+    fn rand_float(self) -> f64 {
+        let next_val: i64 = self.next()
+        return ((next_val as i32) as f64) / 2147483648.0
+    }
+
+    fn rand_int(self, min: i64, max: i64) -> i64 {
+        let range: i64 = max - min + 1
+        return min + (self.next() % range)
+    }
+
+    fn choice<T>(self, items: [T]) -> T {
+        let idx: i32 = self.rand_int(0 as i64, (len(items) - 1) as i64) as i32
+        return items[idx]
+    }
+
+    fn shuffle<T>(self, items: [T]) {
+        let mut i: i32 = len(items) - 1
+        while i > 0 {
+            let j: i32 = self.rand_int(0 as i64, i as i64) as i32
+            let temp = items[i]
+            items[i] = items[j]
+            items[j] = temp
+            i = i - 1
+        }
+    }
+}
+
+fn main() {
+    let rng = RNG.new(1234 as i64)
+
+    let val = rng.rand_int(1 as i64, 100 as i64)
+    print("Random integer: {}", val)
+
+    let x = rng.rand_float()
+    print("Random float: {}", x)
+
+    // The choice and shuffle functions demonstrate RNG usage with arrays.
+    // Example usage of choice and shuffle
+    // (Uncomment the following lines if array indexing with casted indices is supported)
+    let names = ["Alice", "Bob", "Cleo"]
+    let selected = rng.choice(names)
+    print("Picked: {}", selected)
+
+    let numbers = [1, 2, 3, 4, 5]
+    rng.shuffle(numbers)
+    print("Shuffled: {}, {}, {}, {}, {}", numbers[0], numbers[1], numbers[2], numbers[3], numbers[4])
+}


### PR DESCRIPTION
## Summary
- add new opcode `OP_I64_TO_I32`
- emit `OP_I64_TO_I32` for casts from i64 to i32
- implement runtime handling of the new opcode
- extend debug output
- enable choice and shuffle usage in `random_generation_i64.orus`