### PR TITLE
Fix SplitMix64 example

### DIFF
--- a/random64.orus
+++ b/random64.orus
@@ -1,0 +1,49 @@
+struct SplitMix64 {
+    state: i64
+}
+
+impl SplitMix64 {
+    pub fn new(seed: i64) -> SplitMix64 {
+        return SplitMix64{ state: seed }
+    }
+
+    pub fn next(self) -> i64 {
+        let shift30: i64 = 30
+        let shift27: i64 = 27
+        let shift31: i64 = 31
+
+        // 0x9E3779B97F4A7C15 overflows a signed 64-bit literal, so use the
+        // equivalent negative value.
+        self.state = self.state + -7046029254386353131
+
+        let mut z = self.state
+
+        // These constants exceed the range of a signed 64-bit literal. Use
+        // their signed equivalents instead.
+        z = (z ^ (z >> shift30)) * -4658895280553007687  // 0xBF58476D1CE4E5B9
+        z = (z ^ (z >> shift27)) * -7723592293110705685  // 0x94D049BB133111EB
+        z = z ^ (z >> shift31)
+
+        return z
+    }
+
+    pub fn rand_float(self) -> f64 {
+        let val = self.next()
+        // Cast through i32 since direct i64 -> f64 casts are unsupported.
+        let masked: i32 = (val as i32) & 0x7FFFFFFF
+        return (masked as f64) / 2147483648.0
+    }
+
+    pub fn rand_int(self, min: i32, max: i32) -> i32 {
+        let range: i32 = max - min + 1
+        return min + ((self.next() as i32) % range)
+    }
+}
+
+
+fn main() {
+    let rng = SplitMix64.new(2025 as i64)
+
+    print("Random int: {}", rng.rand_int(1, 100))
+    print("Random float: {}", rng.rand_float())
+}


### PR DESCRIPTION
## Summary
- add a working `SplitMix64` implementation example in `random64.orus`
- handle 64-bit constants by using their negative equivalents
- cast through `i32` where `i64`→`f64` casts are unsupported
- simplify main usage without a module prefix