### PR TITLE
Add standard math library

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ The script executes each benchmark program and prints the time spent running it.
   - `errors/` - Error handling tests
   - `generics/` - Tests for generic functionality
 - `include/` - Header files for language components
-- `std/` - Standard library components
+  - `std/` - Standard library modules such as `std/math`
 - `docs/` - Documentation
   - `LANGUAGE.md` – Overview of the language syntax
   - `GENERICS.md` – Notes on the generic programming capabilities

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -368,4 +368,5 @@ print(len(arr))
 - Modules, pattern matching, error handling and `impl` blocks are **fully implemented**.
 - Generics work for basic use cases but lack forward declarations and constraints.
 - The standard library is minimal; more built-ins are planned.
+- Initial modules are available under `std/` such as `std/math` for math helpers.
 

--- a/docs/ORUS_ROADMAP.md
+++ b/docs/ORUS_ROADMAP.md
@@ -3,7 +3,7 @@
 
 This document consolidates the development roadmaps for the Orus language, tracking progress and version increments across multiple development streams.
 
-**Current Version: 0.5.2**
+**Current Version: 0.5.3**
 
 ## Version History
 
@@ -11,6 +11,7 @@ This document consolidates the development roadmaps for the Orus language, track
 - **0.5.0**: Current version with generics, modules, error handling, and garbage collection  
 - **0.5.1**: Added `input()` builtin for basic user input
 - **0.5.2**: Improved diagnostics for repeated module imports
+- **0.5.3**: Introduced `std/math` library with core math utilities
 
 ## Completed Major Features
 
@@ -98,7 +99,7 @@ use std::math
 
 | Module         | Description                                     | Target Version   |
 |----------------|-------------------------------------------------|------------------|
-| `std/math`       | `clamp`, `sqrt`, `average`, constants like `PI` | 0.6.0            |
+| `std/math`       | `clamp`, `sqrt`, `average`, constants like `PI` | 0.5.3            |
 | `std/random`     | LCG `rand`, `rand_int`, `choice`, `shuffle`     | 0.6.0            |
 | `std/functional` | `map`, `filter`, `reduce`                       | 0.6.0+ (depends on function support) |
 | `std/datetime`   | `now()`, `timestamp()`, formatting              | 0.6.0+ (needs runtime `_timestamp`) |
@@ -130,9 +131,9 @@ use std::math
 ## Development Priorities
 
 ### Short-Term (0–3 months)
-- Complete generic forward declarations  
-- Add remaining built-ins: `abs`, `round`, `any`, `all`  
-- Begin core standard library: `math`, `random`, `functional`
+- Complete generic forward declarations
+- Add remaining built-ins: `any`, `all`
+- Expand standard library with modules like `random` and `functional`
 
 ### Medium-Term (3–12 months)
 - Generic constraints and arithmetic  

--- a/std/math.orus
+++ b/std/math.orus
@@ -1,0 +1,108 @@
+pub const PI: f64 = 3.141592653589793
+pub const E: f64 = 2.718281828459045
+pub const TAU: f64 = 6.283185307179586
+
+pub fn abs(x: f64) -> f64 {
+    if x < 0.0 {
+        return -x
+    }
+    return x
+}
+
+pub fn clamp(x: f64, min_val: f64, max_val: f64) -> f64 {
+    if x < min_val {
+        return min_val
+    }
+    if x > max_val {
+        return max_val
+    }
+    return x
+}
+
+pub fn pow(base: f64, exponent: i32) -> f64 {
+    let mut b = base
+    let mut e = exponent
+    let mut result: f64 = 1.0
+    if e < 0 {
+        b = 1.0 / b
+        e = -e
+    }
+    while e > 0 {
+        if (e & 1) == 1 {
+            result = result * b
+        }
+        e = e >> 1
+        b = b * b
+    }
+    return result
+}
+
+pub fn sqrt(x: f64) -> f64 {
+    if x <= 0.0 {
+        return 0.0
+    }
+    let mut guess = x / 2.0
+    let mut last = 0.0
+    while abs(guess - last) > 0.0000001 {
+        last = guess
+        guess = (guess + x / guess) / 2.0
+    }
+    return guess
+}
+
+pub fn floor(x: f64) -> i32 {
+    let i: i32 = x as i32
+    if x < 0.0 and (x != (i as f64)) {
+        return i - 1
+    }
+    return i
+}
+
+pub fn ceil(x: f64) -> i32 {
+    let i: i32 = x as i32
+    if x > 0.0 and (x != (i as f64)) {
+        return i + 1
+    }
+    return i
+}
+
+pub fn round(x: f64) -> i32 {
+    return floor(x + 0.5)
+}
+
+pub fn sign(x: f64) -> i32 {
+    if x > 0.0 {
+        return 1
+    }
+    if x < 0.0 {
+        return -1
+    }
+    return 0
+}
+
+pub fn average(values: [f64]) -> f64 {
+    if len(values) == 0 {
+        return 0.0
+    }
+    return sum(values) / (len(values) as f64)
+}
+
+pub fn median(values: [f64]) -> f64 {
+    if len(values) == 0 {
+        return 0.0
+    }
+    let sortedVals = sorted(values)
+    let mid = len(sortedVals) / 2
+    if (len(sortedVals) & 1) == 1 {
+        return sortedVals[mid]
+    }
+    return (sortedVals[mid - 1] + sortedVals[mid]) / 2.0
+}
+
+pub fn mod(a: i32, b: i32) -> i32 {
+    let r = a % b
+    if r < 0 {
+        return r + b
+    }
+    return r
+}

--- a/tests/stdlib/math_module.orus
+++ b/tests/stdlib/math_module.orus
@@ -1,0 +1,20 @@
+use std::math
+
+fn main() {
+    print(math.abs(-5.0))
+    print(math.clamp(15.0, 0.0, 10.0))
+    print(math.pow(2.0, 8))
+    print(math.sqrt(9.0))
+    print(math.round(3.6))
+    print(math.floor(3.9))
+    print(math.ceil(3.1))
+    print(math.sign(-2.0))
+    let vals = [1.0, 2.0, 3.0]
+    print(math.average(vals))
+    let mids = [3.0, 1.0, 2.0]
+    print(math.median(mids))
+    print(math.mod(-3, 5))
+    print(math.PI)
+    print(math.E)
+    print(math.TAU)
+}


### PR DESCRIPTION
## Summary
- implement `std/math.orus` with common math helpers
- document new module and version bump
- reference `std/math` in project docs
- provide a basic test for the module