### PR TITLE
Embed standard library into binary with fallback loader

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,11 @@
 CC=gcc
+all: debug
 CFLAGS=-I./include -Wall -g
 SRC=$(shell find src -name '*.c')
+STDLIBC=src/vm/builtin_stdlib.c
+STDLIBH=include/builtin_stdlib.h
+$(STDLIBC) $(STDLIBH): tools/gen_stdlib.py $(wildcard std/*.orus)
+	python3 tools/gen_stdlib.py std $(STDLIBC) $(STDLIBH)
 OBJ=$(patsubst src/%.c, build/debug/clox/%.o, $(SRC))
 TARGET=orusc
 RELEASE_TARGET=build/release/clox

--- a/include/builtin_stdlib.h
+++ b/include/builtin_stdlib.h
@@ -1,0 +1,14 @@
+#ifndef BUILTIN_STDLIB_H
+#define BUILTIN_STDLIB_H
+
+typedef struct {
+    const char* name;
+    const char* source;
+} EmbeddedModule;
+
+extern const EmbeddedModule embeddedStdlib[];
+extern const int embeddedStdlibCount;
+const char* getEmbeddedModule(const char* name);
+void dumpEmbeddedStdlib(const char* dir);
+
+#endif

--- a/include/modules.h
+++ b/include/modules.h
@@ -6,6 +6,7 @@
 #include "value.h"
 #include "vm.h"
 #include <stdbool.h>
+#include <time.h>
 
 typedef struct {
     char* name;
@@ -20,11 +21,16 @@ typedef struct {
     Export exports[UINT8_COUNT];
     uint8_t export_count;
     bool executed;
+    char* disk_path;   // path on disk if loaded from file
+    long mtime;        // modification time
+    bool from_embedded; // true if loaded from embedded table
 } Module;
 
 Export* get_export(Module* module, const char* name);
 
 char* load_module_source(const char* resolved_path);
+char* load_module_with_fallback(const char* path, char** disk_path, long* mtime,
+                                bool* from_embedded);
 ASTNode* parse_module_source(const char* source_code, const char* module_name);
 Chunk* compile_module_ast(ASTNode* ast, const char* module_name);
 bool register_module(Module* module);

--- a/include/vm.h
+++ b/include/vm.h
@@ -83,6 +83,9 @@ typedef struct {
     NativeFunction nativeFunctions[MAX_NATIVES];
     int nativeFunctionCount;
 
+    const char* stdPath;
+    bool devMode;
+
     // Garbage collector state
     Obj* objects;
     size_t bytesAllocated;

--- a/src/vm/builtin_stdlib.c
+++ b/src/vm/builtin_stdlib.c
@@ -1,0 +1,34 @@
+#include "../../include/builtin_stdlib.h"
+#include <string.h>
+#include <stdio.h>
+#include <sys/stat.h>
+
+const EmbeddedModule embeddedStdlib[] = {
+    {"std/math.orus", "pub const PI: f64 = 3.141592653589793\npub const E: f64 = 2.718281828459045\npub const TAU: f64 = 6.283185307179586\n\npub fn abs(x: f64) -> f64 {\n    if x < 0.0 {\n        return -x\n    }\n    return x\n}\n\npub fn clamp(x: f64, min_val: f64, max_val: f64) -> f64 {\n    if x < min_val {\n        return min_val\n    }\n    if x > max_val {\n        return max_val\n    }\n    return x\n}\n\npub fn pow(base: f64, exponent: i32) -> f64 {\n    let mut b = base\n    let mut e = exponent\n    let mut result: f64 = 1.0\n    if e < 0 {\n        b = 1.0 / b\n        e = -e\n    }\n    while e > 0 {\n        if (e & 1) == 1 {\n            result = result * b\n        }\n        e = e >> 1\n        b = b * b\n    }\n    return result\n}\n\npub fn sqrt(x: f64) -> f64 {\n    if x <= 0.0 {\n        return 0.0\n    }\n    let mut guess = x / 2.0\n    let mut last = 0.0\n    while abs(guess - last) > 0.0000001 {\n        last = guess\n        guess = (guess + x / guess) / 2.0\n    }\n    return guess\n}\n\npub fn floor(x: f64) -> i32 {\n    let i: i32 = x as i32\n    if x < 0.0 and (x != (i as f64)) {\n        return i - 1\n    }\n    return i\n}\n\npub fn ceil(x: f64) -> i32 {\n    let i: i32 = x as i32\n    if x > 0.0 and (x != (i as f64)) {\n        return i + 1\n    }\n    return i\n}\n\npub fn round(x: f64) -> i32 {\n    return floor(x + 0.5)\n}\n\npub fn sign(x: f64) -> i32 {\n    if x > 0.0 {\n        return 1\n    }\n    if x < 0.0 {\n        return -1\n    }\n    return 0\n}\n\npub fn average(values: [f64]) -> f64 {\n    if len(values) == 0 {\n        return 0.0\n    }\n    return sum(values) / (len(values) as f64)\n}\n\npub fn median(values: [f64]) -> f64 {\n    if len(values) == 0 {\n        return 0.0\n    }\n    let sortedVals = sorted(values)\n    let mid = len(sortedVals) / 2\n    if (len(sortedVals) & 1) == 1 {\n        return sortedVals[mid]\n    }\n    return (sortedVals[mid - 1] + sortedVals[mid]) / 2.0\n}\n\npub fn mod(a: i32, b: i32) -> i32 {\n    let r = a % b\n    if r < 0 {\n        return r + b\n    }\n    return r\n}\n"},
+};
+const int embeddedStdlibCount = sizeof(embeddedStdlib)/sizeof(EmbeddedModule);
+
+const char* getEmbeddedModule(const char* name){
+    for(int i=0;i<embeddedStdlibCount;i++){
+        if(strcmp(embeddedStdlib[i].name,name)==0) return embeddedStdlib[i].source;
+    }
+    return NULL;
+}
+
+static void ensure_dir(const char* path){
+    char tmp[512];
+    strncpy(tmp,path,sizeof(tmp)-1);
+    tmp[sizeof(tmp)-1]=0;
+    for(char* p=tmp+1; *p; p++){ if(*p=='/'){ *p=0; mkdir(tmp,0755); *p='/'; } }
+    mkdir(tmp,0755);
+}
+
+void dumpEmbeddedStdlib(const char* dir){
+    char full[512];
+    for(int i=0;i<embeddedStdlibCount;i++){
+        snprintf(full,sizeof(full),"%s/%s",dir,embeddedStdlib[i].name);
+        char* slash=strrchr(full,'/');
+        if(slash){ *slash=0; ensure_dir(full); *slash='/'; } else { ensure_dir(full); }
+        FILE* f=fopen(full,"w"); if(f){ fputs(embeddedStdlib[i].source,f); fclose(f); }
+    }
+}

--- a/tools/gen_stdlib.py
+++ b/tools/gen_stdlib.py
@@ -1,0 +1,50 @@
+import os, sys
+
+def escape_c(s):
+    return s.replace('\\', r'\\').replace('"', r'\"').replace('\n', r'\n')
+
+if len(sys.argv) != 4:
+    print('Usage: gen_stdlib.py <src_dir> <out_c> <out_h>')
+    sys.exit(1)
+
+src_dir, out_c, out_h = sys.argv[1:4]
+modules = []
+for root, _, files in os.walk(src_dir):
+    for f in files:
+        if f.endswith('.orus'):
+            path = os.path.join(root, f)
+            rel = os.path.relpath(path, src_dir)
+            with open(path, 'r') as fh:
+                code = fh.read()
+            modules.append((os.path.join('std', rel).replace('\\', '/'), code))
+
+with open(out_h, 'w') as h:
+    h.write('#ifndef BUILTIN_STDLIB_H\n#define BUILTIN_STDLIB_H\n\n')
+    h.write('typedef struct {\n    const char* name;\n    const char* source;\n} EmbeddedModule;\n\n')
+    h.write('extern const EmbeddedModule embeddedStdlib[];\n')
+    h.write('extern const int embeddedStdlibCount;\n')
+    h.write('const char* getEmbeddedModule(const char* name);\n')
+    h.write('void dumpEmbeddedStdlib(const char* dir);\n')
+    h.write('\n#endif\n')
+
+with open(out_c, 'w') as c:
+    c.write('#include "../../include/builtin_stdlib.h"\n')
+    c.write('#include <string.h>\n#include <stdio.h>\n#include <sys/stat.h>\n')
+    c.write('\nconst EmbeddedModule embeddedStdlib[] = {\n')
+    for name, code in modules:
+        c.write('    {"%s", "%s"},\n' % (name, escape_c(code)))
+    c.write('};\n')
+    c.write('const int embeddedStdlibCount = sizeof(embeddedStdlib)/sizeof(EmbeddedModule);\n')
+    c.write('\nconst char* getEmbeddedModule(const char* name){\n')
+    c.write('    for(int i=0;i<embeddedStdlibCount;i++){\n')
+    c.write('        if(strcmp(embeddedStdlib[i].name,name)==0) return embeddedStdlib[i].source;\n')
+    c.write('    }\n    return NULL;\n}\n')
+    c.write('\nstatic void ensure_dir(const char* path){\n')
+    c.write('    char tmp[512];\n    strncpy(tmp,path,sizeof(tmp)-1);\n    tmp[sizeof(tmp)-1]=0;\n')
+    c.write('    for(char* p=tmp+1; *p; p++){ if(*p=="/"){ *p=0; mkdir(tmp,0755); *p="/"; } }\n')
+    c.write('    mkdir(tmp,0755);\n}\n')
+    c.write('\nvoid dumpEmbeddedStdlib(const char* dir){\n    char full[512];\n    for(int i=0;i<embeddedStdlibCount;i++){\n')
+    c.write('        snprintf(full,sizeof(full),"%s/%s",dir,embeddedStdlib[i].name);\n')
+    c.write('        char* slash=strrchr(full,\'/\');\n        if(slash){ *slash=0; ensure_dir(full); *slash=\'/\'; } else { ensure_dir(full); }\n')
+    c.write('        FILE* f=fopen(full,"w"); if(f){ fputs(embeddedStdlib[i].source,f); fclose(f); }\n')
+    c.write('    }\n}\n')


### PR DESCRIPTION
## Summary
- generate builtin_stdlib.c/h from `std` modules via `tools/gen_stdlib.py`
- embed standard library sources and expose helper APIs
- extend module loader with disk/embedded fallback and dev reload
- add CLI flags `--std-path`, `--dump-stdlib`, and `--dev`
- store module metadata for reloads
- update Makefile to regenerate builtin stdlib