### PR TITLE
Fix stdlib path detection

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -328,6 +328,7 @@ int main(int argc, const char* argv[]) {
     bool devFlag = false;
     bool dumpStdlib = false;
     const char* cliStdPath = NULL;
+    char defaultStdPath[PATH_MAX];
     const char* path = NULL;
     const char* projectDir = NULL;
 
@@ -360,6 +361,20 @@ int main(int argc, const char* argv[]) {
         } else {
             fprintf(stderr, "Usage: orusc [--trace] [--trace-imports] [--std-path dir] [--dump-stdlib] [--dev] [--project dir] [path]\n");
             return 64;
+        }
+    }
+
+    if (!cliStdPath) {
+        const char* envPath = getenv("ORUS_PATH");
+        if (!envPath || envPath[0] == '\0') {
+            if (realpath(argv[0], defaultStdPath)) {
+                char* slash = strrchr(defaultStdPath, '/');
+                if (slash) {
+                    *slash = '\0';
+                    strncat(defaultStdPath, "/std", sizeof(defaultStdPath) - strlen(defaultStdPath) - 1);
+                    cliStdPath = defaultStdPath;
+                }
+            }
         }
     }
 

--- a/src/vm/modules.c
+++ b/src/vm/modules.c
@@ -43,7 +43,10 @@ char* load_module_with_fallback(const char* path, char** disk_path, long* mtime,
         return source;
     }
     char full[256];
-    snprintf(full, sizeof(full), "%s/%s", vm.stdPath ? vm.stdPath : "std", path);
+    const char* base = vm.stdPath ? vm.stdPath : "std";
+    const char* sub = path;
+    if (strncmp(path, "std/", 4) == 0) sub = path + 4;
+    snprintf(full, sizeof(full), "%s/%s", base, sub);
     source = load_module_source(full);
     if (source) {
         if (disk_path) *disk_path = strdup(full);

--- a/src/vm/vm.c
+++ b/src/vm/vm.c
@@ -66,7 +66,7 @@ void initVM() {
     const char* envTrace = getenv("ORUS_TRACE");
     vm.trace = envTrace && envTrace[0] != '\0';
     const char* envPath = getenv("ORUS_PATH");
-    vm.stdPath = envPath && envPath[0] != '\0' ? envPath : "std";
+    vm.stdPath = envPath && envPath[0] != '\0' ? envPath : NULL;
     const char* envDev = getenv("ORUS_DEV_MODE");
     vm.devMode = envDev && envDev[0] != '\0';
     for (int i = 0; i < UINT8_COUNT; i++) {

--- a/tests/run_all_tests.sh
+++ b/tests/run_all_tests.sh
@@ -11,6 +11,10 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 # Fix the path to the Orus executable
 ORUS_EXECUTABLE="$(cd "$SCRIPT_DIR/.." && pwd)/orusc"
 
+# Ensure the interpreter can locate the standard library even when
+# this script is executed from within the tests directory.
+export ORUS_PATH="$(cd "$SCRIPT_DIR/.." && pwd)/std"
+
 # Overall counters
 passed=0
 failed=0


### PR DESCRIPTION
## Summary
- auto-detect standard library path relative to executable
- avoid duplicate `std` prefix when resolving modules

## Testing
- `make`
- `bash tests/run_all_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_684bf8b7d31c8325a98cd7ee39c7d39c