### PR TITLE
Add suppression for fallback warning

### DIFF
--- a/include/vm.h
+++ b/include/vm.h
@@ -85,6 +85,7 @@ typedef struct {
 
     const char* stdPath;
     bool devMode;
+    bool suppressWarnings;
 
     // Garbage collector state
     Obj* objects;

--- a/src/main.c
+++ b/src/main.c
@@ -327,6 +327,7 @@ int main(int argc, const char* argv[]) {
     bool traceImportsFlag = false;
     bool devFlag = false;
     bool dumpStdlib = false;
+    bool suppressWarningsFlag = false;
     const char* cliStdPath = NULL;
     char defaultStdPath[PATH_MAX];
     const char* path = NULL;
@@ -350,6 +351,8 @@ int main(int argc, const char* argv[]) {
             dumpStdlib = true;
         } else if (strcmp(argv[i], "--dev") == 0) {
             devFlag = true;
+        } else if (strcmp(argv[i], "--suppress-warnings") == 0) {
+            suppressWarningsFlag = true;
         } else if (strcmp(argv[i], "--project") == 0) {
             if (i + 1 >= argc) {
                 fprintf(stderr, "Usage: orusc --project <dir>\n");
@@ -359,7 +362,7 @@ int main(int argc, const char* argv[]) {
         } else if (!path) {
             path = argv[i];
         } else {
-            fprintf(stderr, "Usage: orusc [--trace] [--trace-imports] [--std-path dir] [--dump-stdlib] [--dev] [--project dir] [path]\n");
+            fprintf(stderr, "Usage: orusc [--trace] [--trace-imports] [--std-path dir] [--dump-stdlib] [--dev] [--suppress-warnings] [--project dir] [path]\n");
             return 64;
         }
     }
@@ -383,6 +386,7 @@ int main(int argc, const char* argv[]) {
     if (devFlag) vm.devMode = true;
     if (traceFlag) vm.trace = true;
     if (traceImportsFlag) traceImports = true;
+    if (suppressWarningsFlag) vm.suppressWarnings = true;
 
     if (dumpStdlib) {
         dumpEmbeddedStdlib(vm.stdPath);

--- a/src/vm/modules.c
+++ b/src/vm/modules.c
@@ -59,7 +59,9 @@ char* load_module_with_fallback(const char* path, char** disk_path, long* mtime,
     const char* embedded = getEmbeddedModule(path);
     if (embedded) {
         if (from_embedded) *from_embedded = true;
-        fprintf(stderr, "[warning] Falling back to embedded module %s\n", path);
+        if (!vm.suppressWarnings) {
+            fprintf(stderr, "[warning] Falling back to embedded module %s\n", path);
+        }
         return strdup(embedded);
     }
     return NULL;

--- a/src/vm/vm.c
+++ b/src/vm/vm.c
@@ -69,6 +69,8 @@ void initVM() {
     vm.stdPath = envPath && envPath[0] != '\0' ? envPath : NULL;
     const char* envDev = getenv("ORUS_DEV_MODE");
     vm.devMode = envDev && envDev[0] != '\0';
+    const char* envSuppress = getenv("ORUS_SUPPRESS_WARNINGS");
+    vm.suppressWarnings = envSuppress && envSuppress[0] != '\0';
     for (int i = 0; i < UINT8_COUNT; i++) {
         vm.loadedModules[i] = NULL;
     }


### PR DESCRIPTION
## Summary
- make fallback warnings optional via `vm.suppressWarnings`
- add `--suppress-warnings` CLI flag
- support `ORUS_SUPPRESS_WARNINGS` environment variable