### PR TITLE
Seed random with timestamp

### DIFF
--- a/docs/BUILTINS.md
+++ b/docs/BUILTINS.md
@@ -21,6 +21,7 @@ description.
 | `input(prompt)` | Display a prompt and return a line of user input. |
 | `int(text)` | Convert a string to an `i32`, raising an error on failure. |
 | `float(text)` | Convert a string to an `f64`, raising an error on failure. |
+| `timestamp()` | Return the current UNIX timestamp as an `i64`. |
 | `sorted(array, key, reverse)` | Return a new array with the elements sorted. The `key` argument is optional and reserved for future use. `reverse` may be passed as the second argument when no key is provided. |
 
 ### `sorted`

--- a/docs/ORUS_ROADMAP.md
+++ b/docs/ORUS_ROADMAP.md
@@ -103,7 +103,7 @@ use std::math
 | `std/math`       | `clamp`, `sqrt`, `average`, constants like `PI` | 0.5.3            |
 | `std/random`     | LCG `rand`, `rand_int`, `choice`, `shuffle`     | 0.6.0            |
 | `std/functional` | `map`, `filter`, `reduce`                       | 0.6.0+ (depends on function support) |
-| `std/datetime`   | `now()`, `timestamp()`, formatting              | 0.6.0+ (needs runtime `_timestamp`) |
+| `std/datetime`   | `now()`, `timestamp()`, formatting              | 0.6.0+ |
 | `std/os`         | `cwd()`, file I/O, environment info             | 0.6.0+           |
 | `std/strings`    | `lowercase`, `trim`, `split`, `replace`         | 0.6.0+           |
 

--- a/docs/RANDOM_MODULE_LIMITATIONS.md
+++ b/docs/RANDOM_MODULE_LIMITATIONS.md
@@ -2,4 +2,4 @@
 
 Prior versions of Orus lacked global mutable variables, blocking an implementation of `std/random`. With the addition of `static mut` declarations the module can now keep state between calls.
 
-The `std/random` module uses a simple linear congruential generator seeded at startup. Functions `rand()`, `rand_int`, `choice`, and `shuffle` provide basic random utilities without external dependencies.
+The `std/random` module uses a simple linear congruential generator. The state is seeded with the current timestamp on first use so that calls return different values across runs. Functions `rand()`, `rand_int`, `choice`, and `shuffle` provide basic random utilities without external dependencies.

--- a/src/compiler/compiler.c
+++ b/src/compiler/compiler.c
@@ -1421,6 +1421,14 @@ static void typeCheckNode(Compiler* compiler, ASTNode* node) {
                 }
                 node->valueType = getPrimitiveType(TYPE_F64);
                 break;
+            } else if (!fromModule && tokenEquals(node->data.call.name, "timestamp")) {
+                if (node->data.call.argCount != 0) {
+                    emitBuiltinArgCountError(compiler, &node->data.call.name,
+                                            "timestamp", 0, node->data.call.argCount);
+                    return;
+                }
+                node->valueType = getPrimitiveType(TYPE_I64);
+                break;
             } else if (!fromModule && tokenEquals(node->data.call.name, "push")) {
                 if (node->data.call.argCount != 2) {
                     emitBuiltinArgCountError(compiler, &node->data.call.name,

--- a/src/vm/builtin_stdlib.c
+++ b/src/vm/builtin_stdlib.c
@@ -4,8 +4,9 @@
 #include <sys/stat.h>
 
 const EmbeddedModule embeddedStdlib[] = {
+    {"std/random.orus", "use std::datetime\n\nstatic mut STATE: i64 = 0\n\nfn next_i64() -> i64 {\n    if STATE == 0 as i64 {\n        STATE = datetime.now() as i64\n    }\n    // ANSI C LCG parameters\n    let a: i64 = 1103515245\n    let c: i64 = 12345\n    let m: i64 = 2147483648\n    STATE = (STATE * a + c) % m\n    return STATE\n}\n\npub fn rand() -> f64 {\n    return (next_i64() as f64) / 2147483648.0\n}\n\npub fn rand_int(min: i32, max: i32) -> i32 {\n    let range: i64 = (max - min + 1) as i64\n    return min + (next_i64() % range) as i32\n}\n\npub fn choice<T>(items: [T]) -> T {\n    let idx: i32 = rand_int(0, len(items) - 1)\n    return items[idx]\n}\n\npub fn shuffle<T>(items: [T]) {\n    let mut i: i32 = len(items) - 1\n    while i > 0 {\n        let j: i32 = rand_int(0, i)\n        let temp = items[i]\n        items[i] = items[j]\n        items[j] = temp\n        i = i - 1\n    }\n}\n"},
+    {"std/datetime.orus", "pub fn now() -> i64 {\n    return timestamp()\n}\n"},
     {"std/math.orus", "pub const PI: f64 = 3.141592653589793\npub const E: f64 = 2.718281828459045\npub const TAU: f64 = 6.283185307179586\n\npub fn abs(x: f64) -> f64 {\n    if x < 0.0 {\n        return -x\n    }\n    return x\n}\n\npub fn clamp(x: f64, min_val: f64, max_val: f64) -> f64 {\n    if x < min_val {\n        return min_val\n    }\n    if x > max_val {\n        return max_val\n    }\n    return x\n}\n\npub fn pow(base: f64, exponent: i32) -> f64 {\n    let mut b = base\n    let mut e = exponent\n    let mut result: f64 = 1.0\n    if e < 0 {\n        b = 1.0 / b\n        e = -e\n    }\n    while e > 0 {\n        if (e & 1) == 1 {\n            result = result * b\n        }\n        e = e >> 1\n        b = b * b\n    }\n    return result\n}\n\npub fn sqrt(x: f64) -> f64 {\n    if x <= 0.0 {\n        return 0.0\n    }\n    let mut guess = x / 2.0\n    let mut last = 0.0\n    while abs(guess - last) > 0.0000001 {\n        last = guess\n        guess = (guess + x / guess) / 2.0\n    }\n    return guess\n}\n\npub fn floor(x: f64) -> i32 {\n    let i: i32 = x as i32\n    if x < 0.0 and (x != (i as f64)) {\n        return i - 1\n    }\n    return i\n}\n\npub fn ceil(x: f64) -> i32 {\n    let i: i32 = x as i32\n    if x > 0.0 and (x != (i as f64)) {\n        return i + 1\n    }\n    return i\n}\n\npub fn round(x: f64) -> i32 {\n    return floor(x + 0.5)\n}\n\npub fn sign(x: f64) -> i32 {\n    if x > 0.0 {\n        return 1\n    }\n    if x < 0.0 {\n        return -1\n    }\n    return 0\n}\n\npub fn average(values: [f64]) -> f64 {\n    if len(values) == 0 {\n        return 0.0\n    }\n    return sum(values) / (len(values) as f64)\n}\n\npub fn median(values: [f64]) -> f64 {\n    if len(values) == 0 {\n        return 0.0\n    }\n    let sortedVals = sorted(values)\n    let mid = len(sortedVals) / 2\n    if (len(sortedVals) & 1) == 1 {\n        return sortedVals[mid]\n    }\n    return (sortedVals[mid - 1] + sortedVals[mid]) / 2.0\n}\n\npub fn mod(a: i32, b: i32) -> i32 {\n    let r = a % b\n    if r < 0 {\n        return r + b\n    }\n    return r\n}\n"},
-    {"std/random.orus", "static mut STATE: i64 = 1\n\nfn next_i64() -> i64 {\n    // ANSI C LCG parameters\n    let a: i64 = 1103515245\n    let c: i64 = 12345\n    let m: i64 = 2147483648\n    STATE = (STATE * a + c) % m\n    return STATE\n}\n\npub fn rand() -> f64 {\n    return (next_i64() as f64) / 2147483648.0\n}\n\npub fn rand_int(min: i32, max: i32) -> i32 {\n    let range: i64 = (max - min + 1) as i64\n    return min + (next_i64() % range) as i32\n}\n\npub fn choice<T>(items: [T]) -> T {\n    let idx: i32 = rand_int(0, len(items) - 1)\n    return items[idx]\n}\n\npub fn shuffle<T>(items: [T]) {\n    let mut i: i32 = len(items) - 1\n    while i > 0 {\n        let j: i32 = rand_int(0, i)\n        let temp = items[i]\n        items[i] = items[j]\n        items[j] = temp\n        i = i - 1\n    }\n}\n"},
 };
 const int embeddedStdlibCount = sizeof(embeddedStdlib)/sizeof(EmbeddedModule);
 
@@ -20,13 +21,7 @@ static void ensure_dir(const char* path){
     char tmp[512];
     strncpy(tmp,path,sizeof(tmp)-1);
     tmp[sizeof(tmp)-1]=0;
-    for(char* p=tmp+1; *p; p++){
-        if(*p=='/'){
-            *p=0;
-            mkdir(tmp,0755);
-            *p='/';
-        }
-    }
+    for(char* p=tmp+1; *p; p++){ if(*p=="/"){ *p=0; mkdir(tmp,0755); *p="/"; } }
     mkdir(tmp,0755);
 }
 

--- a/src/vm/builtins.c
+++ b/src/vm/builtins.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
 
 #include "../../include/builtins.h"
 #include "../../include/error.h"
@@ -492,6 +493,14 @@ static Value native_module_name(int argCount, Value* args) {
     return STRING_VAL(s);
 }
 
+static Value native_timestamp(int argCount, Value* args) {
+    if (argCount != 0) {
+        vmRuntimeError("timestamp() takes no arguments.");
+        return NIL_VAL;
+    }
+    return I64_VAL((int64_t)time(NULL));
+}
+
 static Value native_module_path(int argCount, Value* args) {
     if (argCount != 1 || !IS_STRING(args[0])) {
         vmRuntimeError("module_path() expects module path string.");
@@ -527,6 +536,7 @@ static BuiltinEntry builtinTable[] = {
     {"input", native_input, 1, TYPE_STRING},
     {"int", native_int, 1, TYPE_I32},
     {"float", native_float, 1, TYPE_F64},
+    {"timestamp", native_timestamp, 0, TYPE_I64},
     {"sorted", native_sorted, -1, TYPE_ARRAY},
     {"module_name", native_module_name, 1, TYPE_STRING},
     {"module_path", native_module_path, 1, TYPE_STRING},

--- a/std/datetime.orus
+++ b/std/datetime.orus
@@ -1,0 +1,3 @@
+pub fn now() -> i64 {
+    return timestamp()
+}

--- a/std/random.orus
+++ b/std/random.orus
@@ -1,6 +1,11 @@
-static mut STATE: i64 = 1
+use std::datetime
+
+static mut STATE: i64 = 0
 
 fn next_i64() -> i64 {
+    if STATE == 0 as i64 {
+        STATE = datetime.now() as i64
+    }
     // ANSI C LCG parameters
     let a: i64 = 1103515245
     let c: i64 = 12345

--- a/tests/stdlib/datetime_module.orus
+++ b/tests/stdlib/datetime_module.orus
@@ -1,0 +1,5 @@
+use std::datetime
+
+fn main() {
+    print(datetime.now())
+}


### PR DESCRIPTION
## Summary
- add new `timestamp()` builtin
- seed `std/random` using the timestamp so numbers vary between runs
- document `timestamp()` builtin
- regenerate embedded stdlib
- update roadmap and random module docs

------
https://chatgpt.com/codex/tasks/task_e_684dbb071d648325a21081506ecfdd9b