### PR TITLE
Use generics with constraints in math module

### DIFF
--- a/std/math.orus
+++ b/std/math.orus
@@ -2,14 +2,15 @@ pub const PI: f64 = 3.141592653589793
 pub const E: f64 = 2.718281828459045
 pub const TAU: f64 = 6.283185307179586
 
-pub fn abs(x: f64) -> f64 {
-    if x < 0.0 {
+pub fn abs<T: Numeric>(x: T) -> T {
+    let zero = x - x
+    if x < zero {
         return -x
     }
     return x
 }
 
-pub fn clamp(x: f64, min_val: f64, max_val: f64) -> f64 {
+pub fn clamp<T: Comparable>(x: T, min_val: T, max_val: T) -> T {
     if x < min_val {
         return min_val
     }
@@ -70,11 +71,12 @@ pub fn round(x: f64) -> i32 {
     return floor(x + 0.5)
 }
 
-pub fn sign(x: f64) -> i32 {
-    if x > 0.0 {
+pub fn sign<T: Numeric>(x: T) -> i32 {
+    let zero = x - x
+    if x > zero {
         return 1
     }
-    if x < 0.0 {
+    if x < zero {
         return -1
     }
     return 0
@@ -99,10 +101,11 @@ pub fn median(values: [f64]) -> f64 {
     return (sortedVals[mid - 1] + sortedVals[mid]) / 2.0
 }
 
-pub fn mod(a: i32, b: i32) -> i32 {
-    let r = a % b
-    if r < 0 {
-        return r + b
+pub fn mod<T: Numeric>(a: T, b: T) -> T {
+    let mut r = a % b
+    let zero = a - a
+    if r < zero {
+        r = r + b
     }
     return r
 }

--- a/tests/stdlib/math_module.orus
+++ b/tests/stdlib/math_module.orus
@@ -2,13 +2,16 @@ use std::math
 
 fn main() {
     print(math.abs(-5.0))
+    print(math.abs(-5))
     print(math.clamp(15.0, 0.0, 10.0))
+    print(math.clamp(15, 0, 10))
     print(math.pow(2.0, 8))
     print(math.sqrt(9.0))
     print(math.round(3.6))
     print(math.floor(3.9))
     print(math.ceil(3.1))
     print(math.sign(-2.0))
+    print(math.sign(-2))
     let vals = [1.0, 2.0, 3.0]
     print(math.average(vals))
     let mids = [3.0, 1.0, 2.0]


### PR DESCRIPTION
## Summary
- update `std/math` helpers to leverage new `Numeric` and `Comparable` constraints
- extend `tests/stdlib/math_module` with integer usages of new generics