### PR TITLE
Remove loop iteration limit

### DIFF
--- a/include/vm.h
+++ b/include/vm.h
@@ -9,7 +9,12 @@
 
 #define STACK_MAX 2048
 #define FRAMES_MAX 256
-#define LOOP_ITERATION_LIMIT 10000
+// The loop iteration limit was originally used to guard against
+// accidental infinite loops during early language development.
+// The interpreter is now mature enough that we no longer enforce
+// a hard iteration cap.  Commenting this out allows loops of any
+// length to execute.
+//#define LOOP_ITERATION_LIMIT 10000
 #define TRY_MAX 64
 #define MAX_NATIVES 64
 

--- a/src/vm/vm.c
+++ b/src/vm/vm.c
@@ -1361,13 +1361,16 @@ static InterpretResult run() {
                 // Use the global loop counter defined at the start of run()
                 absolute_loop_count++;
                 
-                // If the loop has iterated too many times, it's likely an infinite loop
+                // If a loop iteration limit is defined, guard against runaway
+                // loops. The check is compiled out when the limit is disabled.
+#ifdef LOOP_ITERATION_LIMIT
                 if (absolute_loop_count > LOOP_ITERATION_LIMIT) {
-                    fprintf(stderr, "ERROR: Loop iteration limit exceeded (%d). "
-                           "Forced termination to prevent infinite loop.\n",
-                           LOOP_ITERATION_LIMIT);
+                    fprintf(stderr, "ERROR: Loop iteration limit exceeded (%d)."
+                            " Forced termination to prevent infinite loop.\n",
+                            LOOP_ITERATION_LIMIT);
                     return INTERPRET_RUNTIME_ERROR;
                 }
+#endif
                 vm.ip -= offset;
 
                 break;

--- a/tests/edge_cases/unbounded_loop.orus
+++ b/tests/edge_cases/unbounded_loop.orus
@@ -1,0 +1,9 @@
+// Execute a loop that exceeds the previous iteration limit to ensure
+// the VM no longer stops execution after 10k iterations.
+fn main() {
+    let mut i: i32 = 0
+    while i < 20000 {
+        i = i + 1
+    }
+    print(i)
+}


### PR DESCRIPTION
## Summary
- allow unlimited loop iterations by commenting out `LOOP_ITERATION_LIMIT`
- guard loop limit check with `#ifdef`
- add a test that performs 20k iterations