### PR TITLE
Add timing to benchmarks and use collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ bash benchmarks/run_benchmarks.sh
 ```
 
 The script executes each benchmark program and prints the time spent running it.
+Each benchmark also reports its own elapsed time using `timestamp()` so they can
+be executed individually and still provide timing information.
 
 ## Repository layout
 

--- a/benchmarks/fibonacci.orus
+++ b/benchmarks/fibonacci.orus
@@ -22,9 +22,15 @@ fn fibonacci_iter(n: i32) -> i32 {
 }
 
 fn main() {
-    let mut result: i32 = 0
+    let start = timestamp()
+    let mut results: [i32] = []
     for i in 0..500 {
-        result = fibonacci_iter(20)
+        let value = fibonacci_iter(20)
+        results.push(value)
     }
-    print(result)
+    // Print the last computed value to match previous behavior
+    let last = results[len(results) - 1]
+    print(last)
+    let elapsed = timestamp() - start
+    print(elapsed)
 }

--- a/benchmarks/sum.orus
+++ b/benchmarks/sum.orus
@@ -1,7 +1,12 @@
 fn main() {
+    let start = timestamp()
+    let mut numbers: [i32] = []
     let mut sum: i32 = 0
     for i in 0..1000 {
         sum = sum + i
+        numbers.push(i)
     }
     print(sum)
+    let elapsed = timestamp() - start
+    print(elapsed)
 }


### PR DESCRIPTION
## Summary
- store fibonacci results in a dynamic array and print elapsed time
- store numbers used in `sum.orus` and print elapsed time
- mention new benchmark output in README

## Testing
- `bash tests/run_all_tests.sh`
- `bash benchmarks/run_benchmarks.sh`

------
https://chatgpt.com/codex/tasks/task_e_684ff3002608832588e664af9a0c6713