### PR TITLE
Update benchmark to use precise timing

### DIFF
--- a/benchmarks/comprehensive.orus
+++ b/benchmarks/comprehensive.orus
@@ -1,5 +1,6 @@
 use std::math
 use std::random
+use std::collections
 
 struct Box<T> {
     value: T
@@ -15,12 +16,13 @@ fn main() {
         boxes.push(Box<i32>{ value: random.randint(0, 99) })
     }
 
-    // Count frequency of tens using a fixed array
-    let mut freq: [i32; 10] = [0,0,0,0,0,0,0,0,0,0]
+    // Count frequency of tens using a Map from std::collections
+    let freq = collections.map_new<i32, i32>()
     for i in 0..len(boxes) {
         let b = boxes[i]
         let bucket = b.value / 10
-        freq[bucket] = freq[bucket] + 1
+        let count = collections.map_get<i32, i32>(freq, bucket, 0)
+        collections.map_put<i32, i32>(freq, bucket, count + 1)
     }
 
     // Perform some math heavy work
@@ -30,10 +32,13 @@ fn main() {
     }
     print(math.round(total))
 
-    // Iterate over the frequency array
-    for i in 0..len(freq) {
-        print(i * 10)
-        print(freq[i])
+    // Iterate over the frequency map
+    let keys = collections.map_keys<i32, i32>(freq)
+    for i in 0..len(keys) {
+        let k = keys[i]
+        let v = collections.map_get<i32, i32>(freq, k, 0)
+        print(k * 10)
+        print(v)
     }
 
     // Print elapsed seconds

--- a/src/compiler/compiler.c
+++ b/src/compiler/compiler.c
@@ -1560,7 +1560,7 @@ static void typeCheckNode(Compiler* compiler, ASTNode* node) {
                                             "timestamp", 0, node->data.call.argCount);
                     return;
                 }
-                node->valueType = getPrimitiveType(TYPE_I64);
+                node->valueType = getPrimitiveType(TYPE_F64);
                 break;
             } else if (!fromModule && tokenEquals(node->data.call.name, "push")) {
                 if (node->data.call.argCount != 2) {

--- a/src/vm/builtins.c
+++ b/src/vm/builtins.c
@@ -6,6 +6,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
+#include <sys/time.h>
 
 #include "../../include/builtins.h"
 #include "../../include/error.h"
@@ -648,7 +649,11 @@ static Value native_timestamp(int argCount, Value* args) {
         vmRuntimeError("timestamp() takes no arguments.");
         return NIL_VAL;
     }
-    return I64_VAL((int64_t)time(NULL));
+
+    struct timeval tv;
+    gettimeofday(&tv, NULL);
+    double seconds = (double)tv.tv_sec + (double)tv.tv_usec / 1000000.0;
+    return F64_VAL(seconds);
 }
 
 /**
@@ -695,7 +700,7 @@ static BuiltinEntry builtinTable[] = {
     {"input", native_input, 1, TYPE_STRING},
     {"int", native_int, 1, TYPE_I32},
     {"float", native_float, 1, TYPE_F64},
-    {"timestamp", native_timestamp, 0, TYPE_I64},
+    {"timestamp", native_timestamp, 0, TYPE_F64},
     {"sorted", native_sorted, -1, TYPE_ARRAY},
     {"module_name", native_module_name, 1, TYPE_STRING},
     {"module_path", native_module_path, 1, TYPE_STRING},


### PR DESCRIPTION
## Summary
- fix return type of `timestamp()` to provide sub-second precision
- adjust compiler's builtin table for new return type
- use collections utilities in the comprehensive benchmark