### PR TITLE
Default numeric literals to i64 with overflow checks

### DIFF
--- a/src/parser/parser.c
+++ b/src/parser/parser.c
@@ -295,9 +295,6 @@ static ASTNode* parseNumber(Parser* parser) {
                 node = createLiteralNode(U64_VAL(uval));
                 node->valueType = createPrimitiveType(TYPE_U64);
             }
-        } else if (uval <= INT32_MAX) {
-            node = createLiteralNode(I32_VAL((int32_t)uval));
-            node->valueType = createPrimitiveType(TYPE_I32);
         } else if (uval <= INT64_MAX) {
             node = createLiteralNode(I64_VAL((int64_t)uval));
             node->valueType = createPrimitiveType(TYPE_I64);


### PR DESCRIPTION
## Summary
- default integer literals to `i64`
- warn/error on overflow for `i32`/`i64` arithmetic
- handle safe assignment of i64 literals to i32 variables