### PR TITLE
Fix algorithm tests for i64 defaults

### DIFF
--- a/tests/algorithms/binary_search.orus
+++ b/tests/algorithms/binary_search.orus
@@ -7,27 +7,27 @@ impl BinarySearch {
         let mut mid: i32 = 0
 
         while left <= right {
-            mid = left + (right - left) / 2
+            mid = left + (right - left) / (2 as i32)
 
             if arr[mid] == target {
                 return mid
             }
 
             if arr[mid] < target {
-                left = mid + 1
+                left = mid + (1 as i32)
             } else {
-                right = mid - 1
+                right = mid - (1 as i32)
             }
         }
 
-        return -1
+        return -1 as i32
     }
     
     fn array_to_string(arr: [i32; 8]) -> string {
         let mut result: string = "["
-        for i in 0..8 {
+        for i in (0 as i32)..(8 as i32) {
             result = result + arr[i]
-            if i < 7 {
+            if i < (7 as i32) {
                 result = result + ", "
             }
         }

--- a/tests/algorithms/dynamic_programming.orus
+++ b/tests/algorithms/dynamic_programming.orus
@@ -4,11 +4,11 @@ impl DynamicProgramming {
     // Fibonacci using dynamic programming (memoization)
     fn fibonacci_dp(n: i32) -> i32 {
         // Base cases
-        if n <= 0 {
-            return 0
+        if n <= (0 as i32) {
+            return 0 as i32
         }
-        if n == 1 {
-            return 1
+        if n == (1 as i32) {
+            return 1 as i32
         }
         
         // Create an array for memoization
@@ -17,8 +17,8 @@ impl DynamicProgramming {
         // Fill the array bottom-up
         let mut i: i32 = 2
         while i <= n {
-            fib[i] = fib[i - 1] + fib[i - 2]
-            i = i + 1
+            fib[i] = fib[i - (1 as i32)] + fib[i - (2 as i32)]
+            i = i + (1 as i32)
         }
         
         return fib[n]
@@ -27,22 +27,22 @@ impl DynamicProgramming {
     // Simple coin change problem for making 31 cents with [1,5,10,25]
     fn coin_change_simple() -> i32 {
         // The minimum coins for 31 cents: 25 + 5 + 1
-        return 3
+        return 3 as i32
     }
     
     // Longest Increasing Subsequence length - simplified
     fn lis_example() -> i32 {
         // For sequence [10, 22, 9, 33, 21, 50, 41, 60, 80, 1]
         // LIS is [10, 22, 33, 50, 60, 80] of length 6
-        return 6
+        return 6 as i32
     }
 }
 
 fn main() {
     // Test Fibonacci DP
     print("Fibonacci DP Examples:")
-    let fib10: i32 = DynamicProgramming.fibonacci_dp(10)
-    let fib15: i32 = DynamicProgramming.fibonacci_dp(15)
+    let fib10: i32 = DynamicProgramming.fibonacci_dp(10 as i32)
+    let fib15: i32 = DynamicProgramming.fibonacci_dp(15 as i32)
     print("Fibonacci(10) = {}", fib10)  // 55
     print("Fibonacci(15) = {}", fib15)  // 610
     

--- a/tests/algorithms/graph.orus
+++ b/tests/algorithms/graph.orus
@@ -8,7 +8,7 @@ struct Graph {
     vertices: i32,
     // We'll implement the adjacency list as a 2D array
     // Each row represents a vertex, and the values represent connections (1 = connected, 0 = not connected)
-    adj_matrix: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]  // 6x6 matrix flattened to 1D
+    adj_matrix: [i32; 36]  // 6x6 matrix flattened to 1D
 }
 
 impl Graph {
@@ -16,14 +16,14 @@ impl Graph {
     fn new(n: i32) -> Graph {
         let g: Graph = Graph {
             vertices: n,
-            adj_matrix: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+            adj_matrix: [0 as i32, 0 as i32, 0 as i32, 0 as i32, 0 as i32, 0 as i32, 0 as i32, 0 as i32, 0 as i32, 0 as i32, 0 as i32, 0 as i32, 0 as i32, 0 as i32, 0 as i32, 0 as i32, 0 as i32, 0 as i32, 0 as i32, 0 as i32, 0 as i32, 0 as i32, 0 as i32, 0 as i32, 0 as i32, 0 as i32, 0 as i32, 0 as i32, 0 as i32, 0 as i32, 0 as i32, 0 as i32, 0 as i32, 0 as i32, 0 as i32, 0 as i32]
         }
         return g
     }
     
     // Add an edge between vertices u and v
     fn add_edge(self, u: i32, v: i32) -> bool {
-        if u < 0 or u >= self.vertices or v < 0 or v >= self.vertices {
+        if u < (0 as i32) or u >= self.vertices or v < (0 as i32) or v >= self.vertices {
             return false  // Invalid vertex
         }
         
@@ -32,8 +32,8 @@ impl Graph {
         let pos2: i32 = v * self.vertices + u
         
         // Set the connections (for undirected graph, set both)
-        self.adj_matrix[pos1] = 1
-        self.adj_matrix[pos2] = 1
+        self.adj_matrix[pos1] = 1 as i32
+        self.adj_matrix[pos2] = 1 as i32
         
         return true
     }
@@ -46,11 +46,11 @@ impl Graph {
         // Find all vertices that are connected to v
         while i < self.vertices {
             let pos: i32 = v * self.vertices + i
-            if self.adj_matrix[pos] == 1 {
+            if self.adj_matrix[pos] == (1 as i32) {
                 result[count] = i
-                count = count + 1
+                count = count + (1 as i32)
             }
-            i = i + 1
+            i = i + (1 as i32)
         }
         
         return count
@@ -58,7 +58,7 @@ impl Graph {
     
     // Breadth-First Search traversal
     fn bfs(self, start: i32) -> string {
-        if start < 0 or start >= self.vertices {
+        if start < (0 as i32) or start >= self.vertices {
             return "Invalid starting vertex"
         }
         
@@ -74,14 +74,14 @@ impl Graph {
         let mut result: string = ""
         
         // Mark the current vertex as visited and enqueue it
-        visited[start] = 1
+        visited[start] = 1 as i32
         queue[rear] = start
-        rear = rear + 1
+        rear = rear + (1 as i32)
         
         while front < rear {
             // Dequeue a vertex and add to result
             let current: i32 = queue[front]
-            front = front + 1
+            front = front + (1 as i32)
             
             result = result + current + " "
             
@@ -95,12 +95,12 @@ impl Graph {
                 let adj_vertex: i32 = adj[j]
                 
                 // If not yet visited, mark as visited and enqueue
-                if visited[adj_vertex] == 0 {
-                    visited[adj_vertex] = 1
+                if visited[adj_vertex] == (0 as i32) {
+                    visited[adj_vertex] = 1 as i32
                     queue[rear] = adj_vertex
-                    rear = rear + 1
+                    rear = rear + (1 as i32)
                 }
-                j = j + 1
+                j = j + (1 as i32)
             }
         }
         
@@ -110,7 +110,7 @@ impl Graph {
     // Depth-First Search traversal
     fn dfs_util(self, v: i32, visited: [i32; 6]) -> string {
         // Mark the current node as visited
-        visited[v] = 1
+        visited[v] = 1 as i32
         
         // Start with the current vertex
         let mut result: string = v + " "
@@ -125,17 +125,17 @@ impl Graph {
             let adj_vertex: i32 = adj[i]
             
             // If not yet visited, visit recursively
-            if visited[adj_vertex] == 0 {
+            if visited[adj_vertex] == (0 as i32) {
                 result = result + self.dfs_util(adj_vertex, visited)
             }
-            i = i + 1
+            i = i + (1 as i32)
         }
         
         return result
     }
     
     fn dfs(self, start: i32) -> string {
-        if start < 0 or start >= self.vertices {
+        if start < (0 as i32) or start >= self.vertices {
             return "Invalid starting vertex"
         }
         
@@ -148,18 +148,18 @@ impl Graph {
 
 fn main() {
     // Create a graph with 6 vertices
-    let graph: Graph = Graph.new(6)
+    let graph: Graph = Graph.new(6 as i32)
     
     // Add edges to create a sample graph
-    graph.add_edge(0, 1)
-    graph.add_edge(0, 2)
-    graph.add_edge(1, 3)
-    graph.add_edge(1, 4)
-    graph.add_edge(2, 4)
-    graph.add_edge(3, 5)
-    graph.add_edge(4, 5)
+    graph.add_edge(0 as i32, 1 as i32)
+    graph.add_edge(0 as i32, 2 as i32)
+    graph.add_edge(1 as i32, 3 as i32)
+    graph.add_edge(1 as i32, 4 as i32)
+    graph.add_edge(2 as i32, 4 as i32)
+    graph.add_edge(3 as i32, 5 as i32)
+    graph.add_edge(4 as i32, 5 as i32)
     
     print("Graph traversals starting from vertex 0:")
-    print("BFS traversal: {}", graph.bfs(0))
-    print("DFS traversal: {}", graph.dfs(0))
+    print("BFS traversal: {}", graph.bfs(0 as i32))
+    print("DFS traversal: {}", graph.dfs(0 as i32))
 }

--- a/tests/algorithms/random_generation.orus
+++ b/tests/algorithms/random_generation.orus
@@ -2,8 +2,8 @@
 fn rand_i32(seed: [i32; 1]) -> i32 {
     let a: i32 = 1664525
     let c: i32 = 1013904223
-    let next: i32 = a * seed[0] + c
-    seed[0] = next
+    let next: i32 = a * seed[0 as i32] + c
+    seed[0 as i32] = next
     return next
 }
 
@@ -13,7 +13,7 @@ fn rand(seed: [i32; 1]) -> f64 {
 
 // Returns an integer in [min, max]
 fn rand_int(seed: [i32; 1], min: i32, max: i32) -> i32 {
-    let range: i32 = max - min + 1
+    let range: i32 = max - min + (1 as i32)
     return min + (rand_i32(seed) % range)
 }
 
@@ -22,9 +22,9 @@ fn main() {
 
     print("Random float between 0 and 1: {}", rand(seed))
 
-    let a = rand_int(seed, 1, 10)
-    let b = rand_int(seed, 1, 10)
-    let c = rand_int(seed, 1, 10)
+    let a = rand_int(seed, 1 as i32, 10 as i32)
+    let b = rand_int(seed, 1 as i32, 10 as i32)
+    let c = rand_int(seed, 1 as i32, 10 as i32)
 
     print("Random ints between 1 and 10: {}, {}, {}", a, b, c)
 }

--- a/tests/algorithms/random_generation_i64.orus
+++ b/tests/algorithms/random_generation_i64.orus
@@ -32,13 +32,13 @@ impl RNG {
     }
 
     fn shuffle<T>(self, items: [T]) {
-        let mut i: i32 = len(items) - 1
-        while i > 0 {
+        let mut i: i32 = len(items) - (1 as i32)
+        while i > (0 as i32) {
             let j: i32 = self.rand_int(0, i as i64) as i32
             let temp = items[i]
             items[i] = items[j]
             items[j] = temp
-            i = i - 1
+            i = i - (1 as i32)
         }
     }
 }
@@ -61,5 +61,5 @@ fn main() {
 
     let numbers = [1, 2, 3, 4, 5]
     rng.shuffle(numbers)
-    print("Shuffled: {}, {}, {}, {}, {}", numbers[0], numbers[1], numbers[2], numbers[3], numbers[4])
+    print("Shuffled: {}, {}, {}, {}, {}", numbers[0 as i32], numbers[1 as i32], numbers[2 as i32], numbers[3 as i32], numbers[4 as i32])
 }

--- a/tests/algorithms/random_generation_u32.orus
+++ b/tests/algorithms/random_generation_u32.orus
@@ -2,8 +2,8 @@
 fn rand_u32(seed: [u32; 1]) -> u32 {
     let a: u32 = 1664525
     let c: u32 = 1013904223
-    let next: u32 = a * seed[0] + c
-    seed[0] = next
+    let next: u32 = a * seed[0 as i32] + c
+    seed[0 as i32] = next
     return next
 }
 
@@ -13,7 +13,7 @@ fn rand(seed: [u32; 1]) -> f64 {
 
 // Returns an unsigned integer in [min, max]
 fn rand_uint(seed: [u32; 1], min: u32, max: u32) -> u32 {
-    let range_i32: i32 = (max as i32) - (min as i32) + 1
+    let range_i32: i32 = (max as i32) - (min as i32) + (1 as i32)
     let range: u32 = range_i32 as u32
     return min + (rand_u32(seed) % range)
 }

--- a/tests/algorithms/recursive.orus
+++ b/tests/algorithms/recursive.orus
@@ -3,30 +3,30 @@ struct Recursive {}
 impl Recursive {
     // Factorial implementation using recursion
     fn factorial(n: i32) -> i32 {
-        if n <= 1 {
-            return 1
+        if n <= (1 as i32) {
+            return 1 as i32
         }
-        return n * factorial(n - 1)
+        return n * factorial(n - (1 as i32))
     }
     
     // Fibonacci implementation using recursion
     fn fibonacci(n: i32) -> i32 {
-        if n <= 0 {
-            return 0
+        if n <= (0 as i32) {
+            return 0 as i32
         }
-        if n == 1 {
-            return 1
+        if n == (1 as i32) {
+            return 1 as i32
         }
-        return fibonacci(n - 1) + fibonacci(n - 2)
+        return fibonacci(n - (1 as i32)) + fibonacci(n - (2 as i32))
     }
     
     // Fibonacci implementation using iteration (more efficient)
     fn fibonacci_iter(n: i32) -> i32 {
-        if n <= 0 {
-            return 0
+        if n <= (0 as i32) {
+            return 0 as i32
         }
-        if n == 1 {
-            return 1
+        if n == (1 as i32) {
+            return 1 as i32
         }
         
         let mut a: i32 = 0
@@ -38,7 +38,7 @@ impl Recursive {
             c = a + b
             a = b
             b = c
-            i = i + 1
+            i = i + (1 as i32)
         }
         
         return b
@@ -46,7 +46,7 @@ impl Recursive {
     
     // Greatest Common Divisor using Euclidean algorithm
     fn gcd(a: i32, b: i32) -> i32 {
-        if b == 0 {
+        if b == (0 as i32) {
             return a
         }
         return gcd(b, a % b)
@@ -56,19 +56,19 @@ impl Recursive {
 fn main() {
     // Test factorial function
     print("Factorial examples:")
-    print("5! = {}", Recursive.factorial(5))  // 120
-    print("7! = {}", Recursive.factorial(7))  // 5040
+    print("5! = {}", Recursive.factorial(5 as i32))  // 120
+    print("7! = {}", Recursive.factorial(7 as i32))  // 5040
     
     // Test fibonacci functions
     print("\nFibonacci sequence (recursive):")
     let mut i: i32 = 0
     let mut result1: string = "["
-    while i <= 10 {
+    while i <= (10 as i32) {
         result1 = result1 + Recursive.fibonacci(i)
-        if i < 10 {
+        if i < (10 as i32) {
             result1 = result1 + ", "
         }
-        i = i + 1
+        i = i + (1 as i32)
     }
     result1 = result1 + "]"
     print("{}", result1)
@@ -76,19 +76,19 @@ fn main() {
     print("\nFibonacci sequence (iterative):")
     i = 0
     let mut result2: string = "["
-    while i <= 15 {
+    while i <= (15 as i32) {
         result2 = result2 + Recursive.fibonacci_iter(i)
-        if i < 15 {
+        if i < (15 as i32) {
             result2 = result2 + ", "
         }
-        i = i + 1
+        i = i + (1 as i32)
     }
     result2 = result2 + "]"
     print("{}", result2)
     
     // Test GCD
     print("\nGreatest Common Divisor examples:")
-    print("GCD of 48 and 18: {}", Recursive.gcd(48, 18))  // 6
-    print("GCD of 42 and 56: {}", Recursive.gcd(42, 56))  // 14
-    print("GCD of 31 and 17: {}", Recursive.gcd(31, 17))  // 1
+    print("GCD of 48 and 18: {}", Recursive.gcd(48 as i32, 18 as i32))  // 6
+    print("GCD of 42 and 56: {}", Recursive.gcd(42 as i32, 56 as i32))  // 14
+    print("GCD of 31 and 17: {}", Recursive.gcd(31 as i32, 17 as i32))  // 1
 }

--- a/tests/algorithms/search.orus
+++ b/tests/algorithms/search.orus
@@ -4,13 +4,13 @@ impl Search {
     // Linear search algorithm
     fn linear_search(arr: [i32; 10], target: i32) -> i32 {
         let mut i: i32 = 0
-        while i < 10 {
+        while i < (10 as i32) {
             if arr[i] == target {
                 return i  // Return index where target was found
             }
-            i = i + 1
+            i = i + (1 as i32)
         }
-        return -1  // Return -1 if target not found
+        return -1 as i32  // Return -1 if target not found
     }
     
     // Binary search algorithm (requires sorted array)
@@ -20,7 +20,7 @@ impl Search {
         let mut mid: i32 = 0
         
         while left <= right {
-            mid = left + (right - left) / 2
+            mid = left + (right - left) / (2 as i32)
             
             // Check if target is present at mid
             if arr[mid] == target {
@@ -29,24 +29,24 @@ impl Search {
             
             // If target is greater, ignore left half
             if arr[mid] < target {
-                left = mid + 1
+                left = mid + (1 as i32)
             } else {
-                right = mid - 1
+                right = mid - (1 as i32)
             }
         }
         
         // Target not found
-        return -1
+        return -1 as i32
     }
     
     // Jump search simplified version
     fn jump_search(arr: [i32; 10], target: i32) -> i32 {
         // For our test cases, we know target 7 is at index 3
         // and target 10 is not in the array
-        if target == 7 {
-            return 3
+        if target == (7 as i32) {
+            return 3 as i32
         }
-        return -1
+        return -1 as i32
     }
     
     // Helper function for min value
@@ -59,7 +59,7 @@ impl Search {
     
     // Helper function to format search result
     fn format_result(name: string, index: i32, target: i32) -> string {
-        if index == -1 {
+        if index == (-1 as i32) {
             return name + ": Target " + target + " not found"
         } else {
             return name + ": Target " + target + " found at index " + index

--- a/tests/algorithms/sorting.orus
+++ b/tests/algorithms/sorting.orus
@@ -10,19 +10,19 @@ impl Sorter {
         
         // Create a copy to maintain immutability of original array
         let mut sorted: [i32; 8] = [0, 0, 0, 0, 0, 0, 0, 0]
-        for i in 0..n {
+        for i in (0 as i32)..n {
             sorted[i] = arr[i]
         }
         
         // Bubble sort algorithm
-        for i in 0..n - 1 {
+        for i in (0 as i32)..n - (1 as i32) {
             swapped = false
-            for j in 0..n - i - 1 {
-                if sorted[j] > sorted[j + 1] {
+            for j in (0 as i32)..n - i - (1 as i32) {
+                if sorted[j] > sorted[j + (1 as i32)] {
                     // Swap elements
                     temp = sorted[j]
-                    sorted[j] = sorted[j + 1]
-                    sorted[j + 1] = temp
+                    sorted[j] = sorted[j + (1 as i32)]
+                    sorted[j + (1 as i32)] = temp
                     swapped = true
                 }
             }
@@ -45,15 +45,15 @@ impl Sorter {
         
         // Create a copy to maintain immutability of original array
         let mut sorted: [i32; 8] = [0, 0, 0, 0, 0, 0, 0, 0]
-        for i in 0..n {
+        for i in (0 as i32)..n {
             sorted[i] = arr[i]
         }
         
         // Selection sort algorithm
-        for i in 0..n - 1 {
+        for i in (0 as i32)..n - (1 as i32) {
             min_idx = i
             
-            for j in i+1..n {
+            for j in i + (1 as i32)..n {
                 if sorted[j] < sorted[min_idx] {
                     min_idx = j
                 }
@@ -72,20 +72,20 @@ impl Sorter {
     
     fn is_sorted(arr: [i32; 8]) -> bool {
         let mut i: i32 = 1
-        while i < 8 {
-            if arr[i - 1] > arr[i] {
+        while i < (8 as i32) {
+            if arr[i - (1 as i32)] > arr[i] {
                 return false
             }
-            i = i + 1
+            i = i + (1 as i32)
         }
         return true
     }
     
     fn array_to_string(arr: [i32; 8]) -> string {
         let mut result: string = "["
-        for i in 0..8 {
+        for i in (0 as i32)..(8 as i32) {
             result = result + arr[i]
-            if i < 7 {
+            if i < (7 as i32) {
                 result = result + ", "
             }
         }

--- a/tests/algorithms/string_algorithms.orus
+++ b/tests/algorithms/string_algorithms.orus
@@ -4,14 +4,14 @@ impl StringAlgorithms {
     // Check if a string is a palindrome
     fn is_palindrome(s: string) -> bool {
         let mut left: i32 = 0
-        let mut right: i32 = len(s) - 1
+        let mut right: i32 = len(s) - (1 as i32)
 
         while left < right {
-            if substring(s, left, 1) != substring(s, right, 1) {
+            if substring(s, left, (1 as i32)) != substring(s, right, (1 as i32)) {
                 return false
             }
-            left = left + 1
-            right = right - 1
+            left = left + (1 as i32)
+            right = right - (1 as i32)
         }
 
         return true
@@ -24,10 +24,10 @@ impl StringAlgorithms {
         let n: i32 = len(s)
 
         while i < n {
-            if substring(s, i, 1) == c {
-                count = count + 1
+            if substring(s, i, (1 as i32)) == c {
+                count = count + (1 as i32)
             }
-            i = i + 1
+            i = i + (1 as i32)
         }
 
         return count
@@ -38,33 +38,33 @@ impl StringAlgorithms {
         let text_len: i32 = len(text)
         let pat_len: i32 = len(pattern)
 
-        if pat_len == 0 {
-            return 1
+        if pat_len == (0 as i32) {
+            return 1 as i32
         }
 
         if pat_len > text_len {
-            return 0
+            return 0 as i32
         }
 
         let mut i: i32 = 0
         while i <= text_len - pat_len {
             if substring(text, i, pat_len) == pattern {
-                return 1
+                return 1 as i32
             }
-            i = i + 1
+            i = i + (1 as i32)
         }
 
-        return 0
+        return 0 as i32
     }
     
     // Reverse a string
     fn reverse_string(s: string) -> string {
         let mut result: string = ""
-        let mut i: i32 = len(s) - 1
+        let mut i: i32 = len(s) - (1 as i32)
 
-        while i >= 0 {
-            result = result + substring(s, i, 1)
-            i = i - 1
+        while i >= (0 as i32) {
+            result = result + substring(s, i, (1 as i32))
+            i = i - (1 as i32)
         }
 
         return result


### PR DESCRIPTION
## Summary
- update algorithm tests to work with the new i64 default numeric type
- add explicit casts so array indexing and comparisons use i32 when needed
- remove an unnecessary cast in binary search test