### PR TITLE
Enable i64->u32 casts

### DIFF
--- a/include/chunk.h
+++ b/include/chunk.h
@@ -128,6 +128,7 @@ typedef enum {
     OP_I32_TO_I64,
     OP_U32_TO_I64,
     OP_I64_TO_I32,
+    OP_I64_TO_U32,
     OP_I32_TO_U64,
     OP_U32_TO_U64,
     OP_U64_TO_I32,

--- a/src/compiler/compiler.c
+++ b/src/compiler/compiler.c
@@ -716,7 +716,7 @@ static void typeCheckNode(Compiler* compiler, ASTNode* node) {
             } else if ((src->kind == TYPE_I32 &&
                         (dst->kind == TYPE_U32 || dst->kind == TYPE_I64 || dst->kind == TYPE_F64 || dst->kind == TYPE_U64)) ||
                        (src->kind == TYPE_U32 && (dst->kind == TYPE_I32 || dst->kind == TYPE_F64 || dst->kind == TYPE_U64)) ||
-                       (src->kind == TYPE_I64 && dst->kind == TYPE_I32) ||
+                       (src->kind == TYPE_I64 && (dst->kind == TYPE_I32 || dst->kind == TYPE_U32)) ||
                        (src->kind == TYPE_U64 && (dst->kind == TYPE_I32 || dst->kind == TYPE_U32 || dst->kind == TYPE_F64)) ||
                        (src->kind == TYPE_F64 && (dst->kind == TYPE_I32 || dst->kind == TYPE_U32 || dst->kind == TYPE_U64 || dst->kind == TYPE_I64)) ||
                        (src->kind == TYPE_I64 && (dst->kind == TYPE_U64 || dst->kind == TYPE_F64)) ||
@@ -755,6 +755,12 @@ static void typeCheckNode(Compiler* compiler, ASTNode* node) {
                     if (IS_I64(node->left->data.literal)) {
                         int64_t v = AS_I64(node->left->data.literal);
                         node->left->data.literal = I32_VAL((int32_t)v);
+                        node->left->valueType = dst;
+                    }
+                } else if (src->kind == TYPE_I64 && dst->kind == TYPE_U32) {
+                    if (IS_I64(node->left->data.literal)) {
+                        int64_t v = AS_I64(node->left->data.literal);
+                        node->left->data.literal = U32_VAL((uint32_t)v);
                         node->left->valueType = dst;
                     }
                 } else if (src->kind == TYPE_I32 && dst->kind == TYPE_U64) {
@@ -2774,6 +2780,8 @@ static void generateCode(Compiler* compiler, ASTNode* node) {
                 writeOp(compiler, OP_U32_TO_I64);
             } else if (from == TYPE_I64 && to == TYPE_I32) {
                 writeOp(compiler, OP_I64_TO_I32);
+            } else if (from == TYPE_I64 && to == TYPE_U32) {
+                writeOp(compiler, OP_I64_TO_U32);
             } else if (from == TYPE_I32 && to == TYPE_U64) {
                 writeOp(compiler, OP_I32_TO_U64);
             } else if (from == TYPE_U32 && to == TYPE_U64) {

--- a/src/vm/debug.c
+++ b/src/vm/debug.c
@@ -271,6 +271,8 @@ int disassembleInstruction(Chunk* chunk, int offset) {
             return simpleInstruction("OP_U32_TO_I64", offset);
         case OP_I64_TO_I32:
             return simpleInstruction("OP_I64_TO_I32", offset);
+        case OP_I64_TO_U32:
+            return simpleInstruction("OP_I64_TO_U32", offset);
         case OP_I32_TO_U64:
             return simpleInstruction("OP_I32_TO_U64", offset);
         case OP_U32_TO_U64:

--- a/src/vm/vm.c
+++ b/src/vm/vm.c
@@ -47,7 +47,9 @@ static bool checkValueAgainstType(Value value, Type* type) {
     if (!type) return true;
     switch (type->kind) {
         case TYPE_I32: return IS_I32(value);
+        case TYPE_I64: return IS_I64(value);
         case TYPE_U32: return IS_U32(value);
+        case TYPE_U64: return IS_U64(value);
         case TYPE_F64: return IS_F64(value);
         case TYPE_BOOL: return IS_BOOL(value);
         case TYPE_STRING: return IS_STRING(value);
@@ -875,6 +877,15 @@ static InterpretResult run() {
                 }
                 int64_t value = AS_I64(vmPop(&vm));
                 vmPush(&vm, I32_VAL((int32_t)value));
+                break;
+            }
+            case OP_I64_TO_U32: {
+                if (!IS_I64(vmPeek(&vm, 0))) {
+                    RUNTIME_ERROR("Operand must be an integer.");
+                    return INTERPRET_RUNTIME_ERROR;
+                }
+                int64_t value = AS_I64(vmPop(&vm));
+                vmPush(&vm, U32_VAL((uint32_t)value));
                 break;
             }
             case OP_I32_TO_U64: {


### PR DESCRIPTION
## Summary
- add missing `OP_I64_TO_U32` opcode and implementation
- allow i64->u32 conversion in the compiler
- implement runtime handling and debug output
- validate i64/u64 types in runtime type checks