### PR TITLE
Sync typed stack with generic operations

### DIFF
--- a/docs/OPTIMIZATION.md
+++ b/docs/OPTIMIZATION.md
@@ -11,8 +11,8 @@ Improve the execution performance of the Orus language by leveraging its **stati
 | Task                                          | Status      |
 | --------------------------------------------- | ----------- |
 | Type-specialized bytecode generation          | ✅ Done |
-| Avoid boxing/tagging of known primitive types | Not started | 
-| Use typed VM stack/registers for primitives   | Not started |
+| Avoid boxing/tagging of known primitive types | ✅ Done |
+| Use typed VM stack/registers for primitives   | ✅ Done |
 | Lazy typed iterators for `range()`            | Not started |
 | Fast-path array push for primitives           | Not started |
 | Type-based print & builtins dispatch          | In progress |
@@ -37,6 +37,11 @@ Improve the execution performance of the Orus language by leveraging its **stati
 * Store raw types like `int64_t`, `float64_t` directly in VM stack/registers.
 * Only wrap in a `Value` union when dynamic behavior is necessary.
 * Avoid heap allocations for local integer/float values.
+* Initial opcodes now skip runtime type checks for integer arithmetic.
+* Introduced a parallel `int64_t` stack used by 64-bit integer opcodes.
+* Added `vmPushI64` and `vmPopI64` helpers so typed opcodes operate on raw values.
+* Removed runtime type checks for all specialized integer operations.
+* Phase 2 completed with unboxed primitives across the interpreter.
 
 ### 3. Optimize Interpreter Dispatch
 

--- a/include/memory.h
+++ b/include/memory.h
@@ -45,6 +45,22 @@
         (vm)->stackTop = (vm)->stack + oldCapacity;                    \
     }
 
+#define GROW_I64_STACK(vm, oldCapacity, newCapacity) \
+    ((vm)->stackI64 = \
+         GROW_ARRAY(int64_t, (vm)->stackI64, oldCapacity, newCapacity))
+
+#define GROW_I64_STACK_IF_NEEDED(vm)                                   \
+    if ((vm)->stackI64Top - (vm)->stackI64 >= (vm)->stackCapacity) {   \
+        int oldCapacity = (vm)->stackCapacity;                         \
+        (vm)->stackCapacity = GROW_CAPACITY(oldCapacity);              \
+        GROW_I64_STACK(vm, oldCapacity, (vm)->stackCapacity);          \
+        if (!(vm)->stackI64) {                                         \
+            fprintf(stderr, "Failed to allocate memory for i64 stack!\n");\
+            exit(1);                                                   \
+        }                                                              \
+        (vm)->stackI64Top = (vm)->stackI64 + oldCapacity;              \
+    }
+
 // static inline size_t growArray(type, pointer, oldCount, newCount) {
 //     return reallocate(pointer, sizeof(type) * (oldCount), sizeof(type) * (newCount));
 // }

--- a/include/vm.h
+++ b/include/vm.h
@@ -56,6 +56,8 @@ typedef struct {
     uint8_t* ip;
     Value* stack;
     Value* stackTop;
+    int64_t* stackI64;
+    int64_t* stackI64Top;
     int stackCapacity;
     Value globals[UINT8_COUNT];
     Type* globalTypes[UINT8_COUNT];


### PR DESCRIPTION
## Summary
- keep typed stack in sync when popping generic values
- push int64 results to typed stack for arrays and global variables
- use unsigned arithmetic in `binaryOpI64`
- fix modulo for negative numbers on the int64 stack