### PR TITLE
Add register VM integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,9 @@ After building, run the interpreter in two ways:
 # Execute a script file
 ./orusc path/to/script.orus
 
+# Run using the experimental register-based VM
+./orusc --regvm path/to/script.orus
+
 # Execute a project directory
 ./orusc --project path/to/project
 

--- a/docs/REGISTER_VM_ROADMAP.md
+++ b/docs/REGISTER_VM_ROADMAP.md
@@ -63,10 +63,10 @@ Design and implement a high-performance, register-based virtual machine for Orus
 
 | Task                                               | Status  |
 | -------------------------------------------------- | ------- |
-| Enable dual-backend (stack/register) for testing   | Planned |
+| Enable dual-backend (stack/register) for testing   | Done |
 | Port all built-in functions to register model      | Planned |
-| Update compiler backend to emit register bytecode  | Planned |
-| Ensure GC compatibility with register-based frames | Planned |
+| Update compiler backend to emit register bytecode  | In Progress |
+| Ensure GC compatibility with register-based frames | Done |
 
 ---
 

--- a/include/vm.h
+++ b/include/vm.h
@@ -5,6 +5,8 @@
 #include "scanner.h"
 #include "type.h"
 #include "value.h"
+#include "reg_vm.h"
+#include "reg_chunk.h"
 #include <stdbool.h>
 
 #define STACK_INIT_CAPACITY 2048
@@ -101,6 +103,10 @@ typedef struct {
     bool gcPaused;
     bool trace;
     unsigned long instruction_count;
+
+    bool useRegisterVM;
+    RegisterChunk regChunk;
+    RegisterVM regVM;
 } VM;
 
 typedef enum {

--- a/src/vm/memory.c
+++ b/src/vm/memory.c
@@ -338,6 +338,14 @@ void collectGarbage() {
             markValue(vm.chunk->constants.values[i]);
         }
     }
+    if (vm.useRegisterVM) {
+        for (int i = 0; i < REGISTER_COUNT; i++) {
+            markValue(vm.regVM.registers[i]);
+        }
+        for (int i = 0; i < vm.regChunk.constants.count; i++) {
+            markValue(vm.regChunk.constants.values[i]);
+        }
+    }
     if (vm.astRoot != NULL) {
         markObject((Obj*)vm.astRoot);
     }

--- a/src/vm/reg_vm.c
+++ b/src/vm/reg_vm.c
@@ -1,20 +1,24 @@
 #include "../../include/reg_vm.h"
+#include "../../include/vm.h"
+#include "../../include/memory.h"
 #include <string.h>
 
-void initRegisterVM(RegisterVM* vm, RegisterChunk* chunk) {
-    vm->chunk = chunk;
-    vm->ip = chunk->code;
-    memset(vm->registers, 0, sizeof(vm->registers));
+extern VM vm;
+
+void initRegisterVM(RegisterVM* rvm, RegisterChunk* chunk) {
+    rvm->chunk = chunk;
+    rvm->ip = chunk->code;
+    memset(rvm->registers, 0, sizeof(rvm->registers));
 }
 
-void freeRegisterVM(RegisterVM* vm) {
-    (void)vm;
+void freeRegisterVM(RegisterVM* rvm) {
+    (void)rvm;
 }
 
-Value runRegisterVM(RegisterVM* vm) {
+Value runRegisterVM(RegisterVM* rvm) {
 #if defined(__GNUC__) || defined(__clang__)
-    RegisterInstr* ip = vm->ip;
-    Value* regs = vm->registers;
+    RegisterInstr* ip = rvm->ip;
+    Value* regs = rvm->registers;
 
     static void* dispatch[] = {
         &&op_NOP,
@@ -33,7 +37,13 @@ Value runRegisterVM(RegisterVM* vm) {
         &&op_CALL,
     };
 
-#define DISPATCH() goto *dispatch[ip->opcode]
+#define DISPATCH()                                             \
+    do {                                                      \
+        vm.instruction_count++;                               \
+        if (vm.instruction_count % 10000 == 0 && !vm.gcPaused) \
+            collectGarbage();                                 \
+        goto *dispatch[ip->opcode];                           \
+    } while (0)
 
     DISPATCH();
 
@@ -47,7 +57,7 @@ op_MOV:
     DISPATCH();
 
 op_LOAD_CONST:
-    regs[ip->dst] = vm->chunk->constants.values[ip->src1];
+    regs[ip->dst] = rvm->chunk->constants.values[ip->src1];
     ip++;
     DISPATCH();
 
@@ -116,94 +126,98 @@ op_GE_I64: {
 }
 
 op_JUMP:
-    ip = vm->chunk->code + ip->dst;
+    ip = rvm->chunk->code + ip->dst;
     DISPATCH();
 
 op_JZ:
     if ((IS_BOOL(regs[ip->src1]) && !AS_BOOL(regs[ip->src1])) ||
         (IS_I64(regs[ip->src1]) && AS_I64(regs[ip->src1]) == 0)) {
-        ip = vm->chunk->code + ip->dst;
+        ip = rvm->chunk->code + ip->dst;
     } else {
         ip++;
     }
     DISPATCH();
 
 op_CALL:
-    vm->ip = ip + 1;
+    rvm->ip = ip + 1;
     return regs[ip->src1];
 
 #else
     while (true) {
         RegisterInstr instr = *vm->ip++;
+        vm.instruction_count++;
+        if (vm.instruction_count % 10000 == 0 && !vm.gcPaused) {
+            collectGarbage();
+        }
         switch (instr.opcode) {
             case ROP_NOP:
                 break;
             case ROP_MOV:
-                vm->registers[instr.dst] = vm->registers[instr.src1];
+                rvm->registers[instr.dst] = rvm->registers[instr.src1];
                 break;
             case ROP_LOAD_CONST:
-                vm->registers[instr.dst] = vm->chunk->constants.values[instr.src1];
+                rvm->registers[instr.dst] = rvm->chunk->constants.values[instr.src1];
                 break;
             case ROP_ADD_RR: {
-                Value a = vm->registers[instr.src1];
-                Value b = vm->registers[instr.src2];
-                vm->registers[instr.dst] = I64_VAL(AS_I64(a) + AS_I64(b));
+                Value a = rvm->registers[instr.src1];
+                Value b = rvm->registers[instr.src2];
+                rvm->registers[instr.dst] = I64_VAL(AS_I64(a) + AS_I64(b));
                 break;
             }
             case ROP_SUB_RR: {
-                Value a = vm->registers[instr.src1];
-                Value b = vm->registers[instr.src2];
-                vm->registers[instr.dst] = I64_VAL(AS_I64(a) - AS_I64(b));
+                Value a = rvm->registers[instr.src1];
+                Value b = rvm->registers[instr.src2];
+                rvm->registers[instr.dst] = I64_VAL(AS_I64(a) - AS_I64(b));
                 break;
             }
             case ROP_EQ_I64: {
-                int64_t a = AS_I64(vm->registers[instr.src1]);
-                int64_t b = AS_I64(vm->registers[instr.src2]);
-                vm->registers[instr.dst] = BOOL_VAL(a == b);
+                int64_t a = AS_I64(rvm->registers[instr.src1]);
+                int64_t b = AS_I64(rvm->registers[instr.src2]);
+                rvm->registers[instr.dst] = BOOL_VAL(a == b);
                 break;
             }
             case ROP_NE_I64: {
-                int64_t a = AS_I64(vm->registers[instr.src1]);
-                int64_t b = AS_I64(vm->registers[instr.src2]);
-                vm->registers[instr.dst] = BOOL_VAL(a != b);
+                int64_t a = AS_I64(rvm->registers[instr.src1]);
+                int64_t b = AS_I64(rvm->registers[instr.src2]);
+                rvm->registers[instr.dst] = BOOL_VAL(a != b);
                 break;
             }
             case ROP_LT_I64: {
-                int64_t a = AS_I64(vm->registers[instr.src1]);
-                int64_t b = AS_I64(vm->registers[instr.src2]);
-                vm->registers[instr.dst] = BOOL_VAL(a < b);
+                int64_t a = AS_I64(rvm->registers[instr.src1]);
+                int64_t b = AS_I64(rvm->registers[instr.src2]);
+                rvm->registers[instr.dst] = BOOL_VAL(a < b);
                 break;
             }
             case ROP_LE_I64: {
-                int64_t a = AS_I64(vm->registers[instr.src1]);
-                int64_t b = AS_I64(vm->registers[instr.src2]);
-                vm->registers[instr.dst] = BOOL_VAL(a <= b);
+                int64_t a = AS_I64(rvm->registers[instr.src1]);
+                int64_t b = AS_I64(rvm->registers[instr.src2]);
+                rvm->registers[instr.dst] = BOOL_VAL(a <= b);
                 break;
             }
             case ROP_GT_I64: {
-                int64_t a = AS_I64(vm->registers[instr.src1]);
-                int64_t b = AS_I64(vm->registers[instr.src2]);
-                vm->registers[instr.dst] = BOOL_VAL(a > b);
+                int64_t a = AS_I64(rvm->registers[instr.src1]);
+                int64_t b = AS_I64(rvm->registers[instr.src2]);
+                rvm->registers[instr.dst] = BOOL_VAL(a > b);
                 break;
             }
             case ROP_GE_I64: {
-                int64_t a = AS_I64(vm->registers[instr.src1]);
-                int64_t b = AS_I64(vm->registers[instr.src2]);
-                vm->registers[instr.dst] = BOOL_VAL(a >= b);
+                int64_t a = AS_I64(rvm->registers[instr.src1]);
+                int64_t b = AS_I64(rvm->registers[instr.src2]);
+                rvm->registers[instr.dst] = BOOL_VAL(a >= b);
                 break;
             }
             case ROP_JUMP:
-                vm->ip = vm->chunk->code + instr.dst;
+                rvm->ip = rvm->chunk->code + instr.dst;
                 break;
             case ROP_JZ:
-                if ((IS_BOOL(vm->registers[instr.src1]) && !AS_BOOL(vm->registers[instr.src1])) ||
-                    (IS_I64(vm->registers[instr.src1]) && AS_I64(vm->registers[instr.src1]) == 0)) {
-                    vm->ip = vm->chunk->code + instr.dst;
+                if ((IS_BOOL(rvm->registers[instr.src1]) && !AS_BOOL(rvm->registers[instr.src1])) ||
+                    (IS_I64(rvm->registers[instr.src1]) && AS_I64(rvm->registers[instr.src1]) == 0)) {
+                    rvm->ip = rvm->chunk->code + instr.dst;
                 }
                 break;
             case ROP_CALL:
                 /* Simple call to native stub for now */
-                return vm->registers[instr.src1];
+                return rvm->registers[instr.src1];
         }
     }
     return NIL_VAL;


### PR DESCRIPTION
## Summary
- support register VM globally with `useRegisterVM`
- initialize/register register-based runtime structures
- mark register data during garbage collection
- allow modules and main runner to execute through register VM
- add GC checks in register VM dispatch
- document `--regvm` flag
- update roadmap progress