### PR TITLE
Add register usage docs and refine typed inc

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ bash benchmarks/compare_vms.sh
   - `COMPILATION_ROADMAP.md` – Planning for future compilation features
   - `REGISTER_VM_ROADMAP.md` – Steps for migrating to a register-based VM
   - `REGISTER_OPCODE_ROADMAP.md` – Progress on implementing missing opcodes
+  - `REGISTER_USAGE.md` – Register allocation conventions
   - `DEBUGGING_GUIDE.md` – Tips for diagnosing and fixing issues
   - `ADVANCED_GENERICS_TUTORIAL.md` – In-depth guide for generic code
   - `EXAMPLE_SNIPPETS.md` – Short sample programs

--- a/docs/REGISTER_USAGE.md
+++ b/docs/REGISTER_USAGE.md
@@ -1,0 +1,15 @@
+# Register Usage Conventions
+
+To keep register allocation simple during early development the register VM follows
+a fixed usage convention. This allows later phases to implement a real allocator
+while still keeping code readable.
+
+| Register Range | Purpose        |
+| -------------- | -------------- |
+| R0–R15        | Temporaries    |
+| R16–R63       | Local vars     |
+| R64+           | Builtins / VM  |
+
+The compiler currently adheres to this convention when assigning registers for
+basic arithmetic. Future optimization passes can replace this simple scheme with
+a true register allocator.

--- a/include/reg_vm.h
+++ b/include/reg_vm.h
@@ -7,7 +7,11 @@
 typedef struct {
     RegisterChunk* chunk;
     RegisterInstr* ip;
-    Value registers[REGISTER_COUNT];
+    /* Primitive typed register banks */
+    int64_t i64_regs[REGISTER_COUNT];
+    double  f64_regs[REGISTER_COUNT];
+    /* Dynamic Value registers for non-primitive types */
+    Value   registers[REGISTER_COUNT];
 } RegisterVM;
 
 void initRegisterVM(RegisterVM* vm, RegisterChunk* chunk);

--- a/src/compiler/reg_ir.c
+++ b/src/compiler/reg_ir.c
@@ -66,41 +66,53 @@ void chunkToRegisterIR(Chunk* chunk, RegisterChunk* out) {
             }
             case OP_ADD_I64: {
                 if (sp < 2) { offset++; break; }
-                int src2 = stackRegs[--sp];
-                int src1 = stackRegs[sp - 1];
-                RegisterInstr instr = {ROP_ADD_I64, (uint8_t)src1, (uint8_t)src1, (uint8_t)src2};
+                int b = stackRegs[--sp];
+                int a = stackRegs[--sp];
+                int dst = ALLOC_REG();
+                RegisterInstr instr = {ROP_ADD_I64, (uint8_t)dst, (uint8_t)a, (uint8_t)b};
                 writeRegisterInstr(out, instr);
-                RELEASE_REG(src2);
+                RELEASE_REG(a);
+                RELEASE_REG(b);
+                stackRegs[sp++] = dst;
                 offset += 1;
                 break;
             }
             case OP_SUBTRACT_I64: {
                 if (sp < 2) { offset++; break; }
-                int src2 = stackRegs[--sp];
-                int src1 = stackRegs[sp - 1];
-                RegisterInstr instr = {ROP_SUBTRACT_I64, (uint8_t)src1, (uint8_t)src1, (uint8_t)src2};
+                int b = stackRegs[--sp];
+                int a = stackRegs[--sp];
+                int dst = ALLOC_REG();
+                RegisterInstr instr = {ROP_SUBTRACT_I64, (uint8_t)dst, (uint8_t)a, (uint8_t)b};
                 writeRegisterInstr(out, instr);
-                RELEASE_REG(src2);
+                RELEASE_REG(a);
+                RELEASE_REG(b);
+                stackRegs[sp++] = dst;
                 offset += 1;
                 break;
             }
             case OP_MULTIPLY_I64: {
                 if (sp < 2) { offset++; break; }
-                int src2 = stackRegs[--sp];
-                int src1 = stackRegs[sp - 1];
-                RegisterInstr instr = {ROP_MUL_RR, (uint8_t)src1, (uint8_t)src1, (uint8_t)src2};
+                int b = stackRegs[--sp];
+                int a = stackRegs[--sp];
+                int dst = ALLOC_REG();
+                RegisterInstr instr = {ROP_MULTIPLY_I64, (uint8_t)dst, (uint8_t)a, (uint8_t)b};
                 writeRegisterInstr(out, instr);
-                RELEASE_REG(src2);
+                RELEASE_REG(a);
+                RELEASE_REG(b);
+                stackRegs[sp++] = dst;
                 offset += 1;
                 break;
             }
             case OP_DIVIDE_I64: {
                 if (sp < 2) { offset++; break; }
-                int src2 = stackRegs[--sp];
-                int src1 = stackRegs[sp - 1];
-                RegisterInstr instr = {ROP_DIV_RR, (uint8_t)src1, (uint8_t)src1, (uint8_t)src2};
+                int b = stackRegs[--sp];
+                int a = stackRegs[--sp];
+                int dst = ALLOC_REG();
+                RegisterInstr instr = {ROP_DIVIDE_I64, (uint8_t)dst, (uint8_t)a, (uint8_t)b};
                 writeRegisterInstr(out, instr);
-                RELEASE_REG(src2);
+                RELEASE_REG(a);
+                RELEASE_REG(b);
+                stackRegs[sp++] = dst;
                 offset += 1;
                 break;
             }
@@ -234,41 +246,53 @@ void chunkToRegisterIR(Chunk* chunk, RegisterChunk* out) {
             }
             case OP_ADD_F64: {
                 if (sp < 2) { offset++; break; }
-                int src2 = stackRegs[--sp];
-                int src1 = stackRegs[sp - 1];
-                RegisterInstr instr = {ROP_ADD_F64, (uint8_t)src1, (uint8_t)src1, (uint8_t)src2};
+                int b = stackRegs[--sp];
+                int a = stackRegs[--sp];
+                int dst = ALLOC_REG();
+                RegisterInstr instr = {ROP_ADD_F64, (uint8_t)dst, (uint8_t)a, (uint8_t)b};
                 writeRegisterInstr(out, instr);
-                RELEASE_REG(src2);
+                RELEASE_REG(a);
+                RELEASE_REG(b);
+                stackRegs[sp++] = dst;
                 offset += 1;
                 break;
             }
             case OP_SUBTRACT_F64: {
                 if (sp < 2) { offset++; break; }
-                int src2 = stackRegs[--sp];
-                int src1 = stackRegs[sp - 1];
-                RegisterInstr instr = {ROP_SUB_F64, (uint8_t)src1, (uint8_t)src1, (uint8_t)src2};
+                int b = stackRegs[--sp];
+                int a = stackRegs[--sp];
+                int dst = ALLOC_REG();
+                RegisterInstr instr = {ROP_SUB_F64, (uint8_t)dst, (uint8_t)a, (uint8_t)b};
                 writeRegisterInstr(out, instr);
-                RELEASE_REG(src2);
+                RELEASE_REG(a);
+                RELEASE_REG(b);
+                stackRegs[sp++] = dst;
                 offset += 1;
                 break;
             }
             case OP_MULTIPLY_F64: {
                 if (sp < 2) { offset++; break; }
-                int src2 = stackRegs[--sp];
-                int src1 = stackRegs[sp - 1];
-                RegisterInstr instr = {ROP_MUL_F64, (uint8_t)src1, (uint8_t)src1, (uint8_t)src2};
+                int b = stackRegs[--sp];
+                int a = stackRegs[--sp];
+                int dst = ALLOC_REG();
+                RegisterInstr instr = {ROP_MUL_F64, (uint8_t)dst, (uint8_t)a, (uint8_t)b};
                 writeRegisterInstr(out, instr);
-                RELEASE_REG(src2);
+                RELEASE_REG(a);
+                RELEASE_REG(b);
+                stackRegs[sp++] = dst;
                 offset += 1;
                 break;
             }
             case OP_DIVIDE_F64: {
                 if (sp < 2) { offset++; break; }
-                int src2 = stackRegs[--sp];
-                int src1 = stackRegs[sp - 1];
-                RegisterInstr instr = {ROP_DIV_F64, (uint8_t)src1, (uint8_t)src1, (uint8_t)src2};
+                int b = stackRegs[--sp];
+                int a = stackRegs[--sp];
+                int dst = ALLOC_REG();
+                RegisterInstr instr = {ROP_DIV_F64, (uint8_t)dst, (uint8_t)a, (uint8_t)b};
                 writeRegisterInstr(out, instr);
-                RELEASE_REG(src2);
+                RELEASE_REG(a);
+                RELEASE_REG(b);
+                stackRegs[sp++] = dst;
                 offset += 1;
                 break;
             }
@@ -1044,7 +1068,7 @@ void chunkToRegisterIR(Chunk* chunk, RegisterChunk* out) {
                 int tmp = ALLOC_REG();
                 RegisterInstr load = {ROP_LOAD_CONST, (uint8_t)tmp, (uint8_t)constIndex, 0};
                 writeRegisterInstr(out, load);
-                RegisterInstr add = {ROP_ADD_RR, (uint8_t)reg, (uint8_t)reg, (uint8_t)tmp};
+                RegisterInstr add = {ROP_ADD_I64, (uint8_t)reg, (uint8_t)reg, (uint8_t)tmp};
                 writeRegisterInstr(out, add);
                 RELEASE_REG(tmp);
                 offset += 1;


### PR DESCRIPTION
## Summary
- document register allocation conventions
- use `ROP_ADD_I64` for increment operation