### PR TITLE
Clarify register VM debug tracing

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,9 @@ After building, run the interpreter in two ways:
 # Execute a project directory
 ./orusc --project path/to/project
 
+To trace individual register updates during execution, compile with
+`DEBUG_TRACE_EXECUTION` enabled in `reg_vm.c`.
+
 ```
 
 When run in project mode the interpreter searches all `.orus` files for a

--- a/docs/REGISTER_VM_ROADMAP.md
+++ b/docs/REGISTER_VM_ROADMAP.md
@@ -41,7 +41,7 @@ Design and implement a high-performance, register-based virtual machine for Orus
 
 | Task                                                    | Status  |
 | ------------------------------------------------------- | ------- |
-| Implement `MOV`, `LOAD_CONST`, `ADD_RR`, `SUB_RR` ops   | Done |
+| Implement `MOV`, `LOAD_CONST` and type-specific arithmetic ops using a 3-operand format | Done |
 | Implement typed comparison ops: `EQ_I64`, `GT_I64`, etc | Done |
 | Update control flow ops (`JUMP`, `JZ`, `CALL`)          | Done |
 | Update loop constructs to register-indexed form         | Done |


### PR DESCRIPTION
## Summary
- document how to enable register-level tracing in `reg_vm.c`
- update VM roadmap to note 3-operand type-specific arithmetic ops