### PR TITLE
Add IR generator support for new 64-bit ops

### DIFF
--- a/docs/REGISTER_OPCODE_ROADMAP.md
+++ b/docs/REGISTER_OPCODE_ROADMAP.md
@@ -19,8 +19,8 @@ The following tasks cover the migration process. Status markers use:
 | Task | Status |
 | ---- | ------ |
 | Enumerate missing opcodes in `include/reg_chunk.h` | ✅ Done |
-| Implement execution logic in `src/vm/reg_vm.c` | 🔄 In progress |
-| Update IR generator (`src/compiler/reg_ir.c`) | 💤 Pending |
+| Implement execution logic in `src/vm/reg_vm.c` | ✅ Done |
+| Update IR generator (`src/compiler/reg_ir.c`) | 🔄 In progress |
 | Provide debug disassembly support | 💤 Pending |
 | Add unit tests for each opcode | 💤 Pending |
 | Benchmark new instructions | 💤 Pending |

--- a/src/compiler/reg_ir.c
+++ b/src/compiler/reg_ir.c
@@ -619,6 +619,22 @@ void chunkToRegisterIR(Chunk* chunk, RegisterChunk* out) {
                 offset += 1;
                 break;
             }
+            case OP_I64_TO_BOOL: {
+                if (sp < 1) { offset++; break; }
+                int reg = stackRegs[sp - 1];
+                RegisterInstr instr = {ROP_I64_TO_BOOL, (uint8_t)reg, (uint8_t)reg, 0};
+                writeRegisterInstr(out, instr);
+                offset += 1;
+                break;
+            }
+            case OP_U64_TO_BOOL: {
+                if (sp < 1) { offset++; break; }
+                int reg = stackRegs[sp - 1];
+                RegisterInstr instr = {ROP_U64_TO_BOOL, (uint8_t)reg, (uint8_t)reg, 0};
+                writeRegisterInstr(out, instr);
+                offset += 1;
+                break;
+            }
             case OP_BOOL_TO_I32: {
                 if (sp < 1) { offset++; break; }
                 int reg = stackRegs[sp - 1];
@@ -795,6 +811,22 @@ void chunkToRegisterIR(Chunk* chunk, RegisterChunk* out) {
                 offset += 1;
                 break;
             }
+            case OP_I64_TO_U64: {
+                if (sp < 1) { offset++; break; }
+                int reg = stackRegs[sp - 1];
+                RegisterInstr instr = {ROP_I64_TO_U64, (uint8_t)reg, (uint8_t)reg, 0};
+                writeRegisterInstr(out, instr);
+                offset += 1;
+                break;
+            }
+            case OP_U64_TO_I64: {
+                if (sp < 1) { offset++; break; }
+                int reg = stackRegs[sp - 1];
+                RegisterInstr instr = {ROP_U64_TO_I64, (uint8_t)reg, (uint8_t)reg, 0};
+                writeRegisterInstr(out, instr);
+                offset += 1;
+                break;
+            }
             case OP_I64_TO_F64: {
                 if (sp < 1) { offset++; break; }
                 int reg = stackRegs[sp - 1];
@@ -839,6 +871,14 @@ void chunkToRegisterIR(Chunk* chunk, RegisterChunk* out) {
                 if (sp < 1) { offset++; break; }
                 int reg = stackRegs[sp - 1];
                 RegisterInstr instr = {ROP_I64_TO_STRING, (uint8_t)reg, (uint8_t)reg, 0};
+                writeRegisterInstr(out, instr);
+                offset += 1;
+                break;
+            }
+            case OP_U64_TO_STRING: {
+                if (sp < 1) { offset++; break; }
+                int reg = stackRegs[sp - 1];
+                RegisterInstr instr = {ROP_U64_TO_STRING, (uint8_t)reg, (uint8_t)reg, 0};
                 writeRegisterInstr(out, instr);
                 offset += 1;
                 break;

--- a/src/vm/reg_vm.c
+++ b/src/vm/reg_vm.c
@@ -119,6 +119,7 @@ Value runRegisterVM(RegisterVM* rvm) {
         &&op_GC_RESUME,
         &&op_ADD_GENERIC,
         &&op_ADD_I64,
+        &&op_MULTIPLY_I64,
         &&op_ADD_NUMERIC,
         &&op_BOOL_TO_I64,
         &&op_BOOL_TO_U64,
@@ -961,6 +962,17 @@ op_ADD_I64: {
     uint8_t s1 = ip->src1;
     uint8_t s2 = ip->src2;
     i64_regs[dest] = i64_regs[s1] + i64_regs[s2];
+#ifdef DEBUG_TRACE_EXECUTION
+    printf("[Debug] i64_regs[R%d] = %lld\n", dest, (long long)i64_regs[dest]);
+#endif
+    ip++; DISPATCH();
+}
+
+op_MULTIPLY_I64: {
+    uint8_t dest = ip->dst;
+    uint8_t s1 = ip->src1;
+    uint8_t s2 = ip->src2;
+    i64_regs[dest] = i64_regs[s1] * i64_regs[s2];
 #ifdef DEBUG_TRACE_EXECUTION
     printf("[Debug] i64_regs[R%d] = %lld\n", dest, (long long)i64_regs[dest]);
 #endif
@@ -1970,6 +1982,13 @@ op_LEN_STRING:
                 uint64_t a = AS_U64(rvm->registers[instr.src1]);
                 uint64_t b = AS_U64(rvm->registers[instr.src2]);
                 rvm->registers[instr.dst] = U64_VAL(a * b);
+                break;
+            }
+            case ROP_MULTIPLY_I64: {
+                i64_regs[instr.dst] = i64_regs[instr.src1] * i64_regs[instr.src2];
+#ifdef DEBUG_TRACE_EXECUTION
+                printf("[Debug] i64_regs[R%d] = %lld\n", instr.dst, (long long)i64_regs[instr.dst]);
+#endif
                 break;
             }
             case ROP_DIV_U64: {


### PR DESCRIPTION
## Summary
- emit IR for `I64_TO_BOOL`, `U64_TO_BOOL`, `I64_TO_U64`, `U64_TO_I64` and `U64_TO_STRING`
- mark register VM opcode implementation done in roadmap
- start work on IR generator step

## Testing
- `make orusc`
- `bash tests/run_all_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_6852be119f148325b8dea14edab8cc40