### PR TITLE
Implement register >= generic opcode

### DIFF
--- a/src/compiler/reg_ir.c
+++ b/src/compiler/reg_ir.c
@@ -1234,6 +1234,58 @@ void chunkToRegisterIR(Chunk* chunk, RegisterChunk* out) {
                 offset += 1;
                 break;
             }
+            case OP_LESS_GENERIC: {
+                if (sp < 2) { offset++; break; }
+                int b = stackRegs[--sp];
+                int a = stackRegs[--sp];
+                int dst = ALLOC_REG();
+                RegisterInstr instr = {ROP_LESS_GENERIC, (uint8_t)dst, (uint8_t)a, (uint8_t)b};
+                writeRegisterInstr(out, instr);
+                RELEASE_REG(a);
+                RELEASE_REG(b);
+                stackRegs[sp++] = dst;
+                offset += 1;
+                break;
+            }
+            case OP_LESS_EQUAL_GENERIC: {
+                if (sp < 2) { offset++; break; }
+                int b = stackRegs[--sp];
+                int a = stackRegs[--sp];
+                int dst = ALLOC_REG();
+                RegisterInstr instr = {ROP_LESS_EQUAL_GENERIC, (uint8_t)dst, (uint8_t)a, (uint8_t)b};
+                writeRegisterInstr(out, instr);
+                RELEASE_REG(a);
+                RELEASE_REG(b);
+                stackRegs[sp++] = dst;
+                offset += 1;
+                break;
+            }
+            case OP_GREATER_GENERIC: {
+                if (sp < 2) { offset++; break; }
+                int b = stackRegs[--sp];
+                int a = stackRegs[--sp];
+                int dst = ALLOC_REG();
+                RegisterInstr instr = {ROP_GREATER_GENERIC, (uint8_t)dst, (uint8_t)a, (uint8_t)b};
+                writeRegisterInstr(out, instr);
+                RELEASE_REG(a);
+                RELEASE_REG(b);
+                stackRegs[sp++] = dst;
+                offset += 1;
+                break;
+            }
+            case OP_GREATER_EQUAL_GENERIC: {
+                if (sp < 2) { offset++; break; }
+                int b = stackRegs[--sp];
+                int a = stackRegs[--sp];
+                int dst = ALLOC_REG();
+                RegisterInstr instr = {ROP_GREATER_EQUAL_GENERIC, (uint8_t)dst, (uint8_t)a, (uint8_t)b};
+                writeRegisterInstr(out, instr);
+                RELEASE_REG(a);
+                RELEASE_REG(b);
+                stackRegs[sp++] = dst;
+                offset += 1;
+                break;
+            }
             case OP_JUMP_IF_LT_I64: {
                 uint16_t off = (uint16_t)(chunk->code[offset + 1] << 8 | chunk->code[offset + 2]);
                 if (sp < 2) { offset += 3; break; }

--- a/src/vm/reg_vm.c
+++ b/src/vm/reg_vm.c
@@ -200,6 +200,7 @@ Value runRegisterVM(RegisterVM* rvm) {
         &&op_GREATER_EQUAL_U32,
         &&op_GREATER_EQUAL_U64,
         &&op_GREATER_EQUAL_F64,
+        &&op_GREATER_EQUAL_GENERIC,
         &&op_GREATER_GENERIC,
         &&op_EQUAL_I64,
         &&op_MODULO_NUMERIC,
@@ -1544,6 +1545,19 @@ op_GREATER_EQUAL_F64: {
     ip++; DISPATCH();
 }
 
+op_GREATER_EQUAL_GENERIC: {
+    Value a = regs[ip->src1];
+    Value b = regs[ip->src2];
+    if (a.type != b.type) {
+        regs[ip->dst] = NIL_VAL;
+    } else if (a.type == VAL_F64) {
+        regs[ip->dst] = BOOL_VAL(AS_F64(a) >= AS_F64(b));
+    } else {
+        regs[ip->dst] = BOOL_VAL(AS_I64(a) >= AS_I64(b));
+    }
+    ip++; DISPATCH();
+}
+
 op_GREATER_GENERIC: {
     Value a = regs[ip->src1];
     Value b = regs[ip->src2];
@@ -1902,6 +1916,18 @@ op_DIVIDE_NUMERIC: {
                 rvm->registers[instr.dst] = BOOL_VAL(a >= b);
                 break;
             }
+            case ROP_GREATER_EQUAL_GENERIC: {
+                Value a = rvm->registers[instr.src1];
+                Value b = rvm->registers[instr.src2];
+                if (a.type != b.type) {
+                    rvm->registers[instr.dst] = NIL_VAL;
+                } else if (a.type == VAL_F64) {
+                    rvm->registers[instr.dst] = BOOL_VAL(AS_F64(a) >= AS_F64(b));
+                } else {
+                    rvm->registers[instr.dst] = BOOL_VAL(AS_I64(a) >= AS_I64(b));
+                }
+                break;
+            }
             case ROP_GREATER_GENERIC:
                 rvm->registers[instr.dst] = BOOL_VAL(valuesEqual(rvm->registers[instr.src1], rvm->registers[instr.src2]) ? false :
                                                 (rvm->registers[instr.src1].type == VAL_F64 ? AS_F64(rvm->registers[instr.src1]) > AS_F64(rvm->registers[instr.src2])
@@ -1965,6 +1991,18 @@ op_DIVIDE_NUMERIC: {
                 double a = AS_F64(rvm->registers[instr.src1]);
                 double b = AS_F64(rvm->registers[instr.src2]);
                 rvm->registers[instr.dst] = BOOL_VAL(a <= b);
+                break;
+            }
+            case ROP_LESS_EQUAL_GENERIC: {
+                Value a = rvm->registers[instr.src1];
+                Value b = rvm->registers[instr.src2];
+                if (a.type != b.type) {
+                    rvm->registers[instr.dst] = NIL_VAL;
+                } else if (a.type == VAL_F64) {
+                    rvm->registers[instr.dst] = BOOL_VAL(AS_F64(a) <= AS_F64(b));
+                } else {
+                    rvm->registers[instr.dst] = BOOL_VAL(AS_I64(a) <= AS_I64(b));
+                }
                 break;
             }
             case ROP_LESS_GENERIC:

--- a/tests/comparison/generic_ge.orus
+++ b/tests/comparison/generic_ge.orus
@@ -1,0 +1,10 @@
+fn main() {
+    print("5 >= 3 is {}", 5 >= 3)
+    print("5 >= 5 is {}", 5 >= 5)
+    print("5 <= 3 is {}", 5 <= 3)
+    print("5 <= 5 is {}", 5 <= 5)
+    let x: f64 = 2.5
+    let y: f64 = 5.0
+    print("y >= x is {}", y >= x)
+    print("x >= y is {}", x >= y)
+}

--- a/tests/regvm/generic_ge.orus
+++ b/tests/regvm/generic_ge.orus
@@ -1,0 +1,10 @@
+fn main() {
+    print("5 >= 3 is {}", 5 >= 3)
+    print("5 >= 5 is {}", 5 >= 5)
+    print("5 <= 3 is {}", 5 <= 3)
+    print("5 <= 5 is {}", 5 <= 5)
+    let x: f64 = 2.5
+    let y: f64 = 5.0
+    print("y >= x is {}", y >= x)
+    print("x >= y is {}", x >= y)
+}


### PR DESCRIPTION
## Summary
- support comparison ops in the register IR generator
- add generic >= comparison semantics in `reg_vm.c`
- test generic comparisons for parity between stack and register VMs
- implement <= generic comparison in the register VM fallback interpreter