### PR TITLE
Implement missing register ops and typed float comparisons

### DIFF
--- a/tests/arithmetic/i64_negative_modulo.orus
+++ b/tests/arithmetic/i64_negative_modulo.orus
@@ -1,0 +1,5 @@
+// Test modulo with negative operands
+fn main() {
+    print("-5000000001 % 2 = {}", -5000000001 % 2)
+    print("5000000001 % -2 = {}", 5000000001 % -2)
+}


### PR DESCRIPTION
## Summary
- implement NEGATE_F64 and MOD_I64 in register IR
- emit typed f64 comparisons in reg_ir
- correct MOD_I64 behaviour in reg_vm
- add negative modulo test
- implement CALL_NATIVE encoding for register VM