### PR TITLE
Fix register VM dispatch and register sync

### DIFF
--- a/docs/REGISTER_VM_ROADMAP.md
+++ b/docs/REGISTER_VM_ROADMAP.md
@@ -64,7 +64,7 @@ Design and implement a high-performance, register-based virtual machine for Orus
 | Task                                               | Status  |
 | -------------------------------------------------- | ------- |
 | Enable dual-backend (stack/register) for testing   | Done |
-| Port all built-in functions to register model      | Planned |
+| Port all built-in functions to register model      | Done |
 | Update compiler backend to emit register bytecode  | Done |
 | Ensure GC compatibility with register-based frames | Planned |
 

--- a/include/builtins.h
+++ b/include/builtins.h
@@ -5,4 +5,20 @@
 
 void initBuiltins(void);
 
+// Wrapper helpers used by the register VM
+Value builtin_range(Value start, Value end);
+Value builtin_sum(Value array);
+Value builtin_min(Value array);
+Value builtin_max(Value array);
+Value builtin_is_type(Value value, Value type_name);
+Value builtin_input(Value prompt);
+Value builtin_int(Value text);
+Value builtin_float(Value text);
+Value builtin_timestamp(void);
+Value builtin_sorted(Value array, Value key, Value reverse);
+Value builtin_module_name(Value path);
+Value builtin_module_path(Value path);
+Value builtin_native_pow(Value base, Value exp);
+Value builtin_native_sqrt(Value value);
+
 #endif // ORUS_BUILTINS_H

--- a/include/reg_chunk.h
+++ b/include/reg_chunk.h
@@ -237,6 +237,21 @@ typedef enum {
     /* Newly added typed float comparisons */
     ROP_EQ_F64,
     ROP_NE_F64,
+    /* Builtin function opcodes */
+    ROP_RANGE,
+    ROP_SUM,
+    ROP_MIN,
+    ROP_MAX,
+    ROP_IS_TYPE,
+    ROP_INPUT,
+    ROP_INT,
+    ROP_FLOAT,
+    ROP_TIMESTAMP,
+    ROP_SORTED,
+    ROP_MODULE_NAME,
+    ROP_MODULE_PATH,
+    ROP_NATIVE_POW,
+    ROP_NATIVE_SQRT,
 } RegisterOp;
 
 typedef struct {

--- a/src/vm/builtins.c
+++ b/src/vm/builtins.c
@@ -736,6 +736,79 @@ static Value native_module_path(int argCount, Value* args) {
     return STRING_VAL(s);
 }
 
+// ---- Wrapper helpers for register VM ----
+Value builtin_range(Value start, Value end) {
+    Value args[2] = {start, end};
+    return native_range(2, args);
+}
+
+Value builtin_sum(Value array) {
+    Value args[1] = {array};
+    return native_sum(1, args);
+}
+
+Value builtin_min(Value array) {
+    Value args[1] = {array};
+    return native_min(1, args);
+}
+
+Value builtin_max(Value array) {
+    Value args[1] = {array};
+    return native_max(1, args);
+}
+
+Value builtin_is_type(Value value, Value type_name) {
+    Value args[2] = {value, type_name};
+    return native_is_type(2, args);
+}
+
+Value builtin_input(Value prompt) {
+    Value args[1] = {prompt};
+    return native_input(1, args);
+}
+
+Value builtin_int(Value text) {
+    Value args[1] = {text};
+    return native_int(1, args);
+}
+
+Value builtin_float(Value text) {
+    Value args[1] = {text};
+    return native_float(1, args);
+}
+
+Value builtin_timestamp(void) {
+    return native_timestamp(0, NULL);
+}
+
+Value builtin_sorted(Value array, Value key, Value reverse) {
+    Value args[3] = {array, key, reverse};
+    int argc = 1;
+    if (!IS_NIL(key)) argc = 2;
+    if (!IS_NIL(reverse)) argc = 3;
+    return native_sorted(argc, args);
+}
+
+Value builtin_module_name(Value path) {
+    Value args[1] = {path};
+    return native_module_name(1, args);
+}
+
+Value builtin_module_path(Value path) {
+    Value args[1] = {path};
+    return native_module_path(1, args);
+}
+
+Value builtin_native_pow(Value base, Value exp) {
+    Value args[2] = {base, exp};
+    return native_pow(2, args);
+}
+
+Value builtin_native_sqrt(Value value) {
+    Value args[1] = {value};
+    return native_sqrt(1, args);
+}
+
 /**
  * Table entry describing a builtin function.
  */


### PR DESCRIPTION
## Summary
- align register VM dispatch table with implemented ops
- add helper macros for keeping typed registers in sync
- update MOV, LOAD_CONST and constant ops to update typed registers
- propagate results from typed operations back to generic registers
- port built-in functions to register VM opcodes
- update roadmap to mark built-in port completed

## Testing
- `make`
- `bash tests/run_all_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68536d786f5c8325afd9e7fec4f5837f