### PR TITLE
Fix register VM opcode mapping

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -216,6 +216,15 @@ static void runFile(const char* path) {
     }
     vm.astRoot = NULL;
     initRegisterVM(&vm.regVM, &vm.regChunk);
+    if (vm.trace) {
+#ifdef DEBUG_TRACE_EXECUTION
+        disassembleRegisterChunk(&vm.regChunk, "register chunk");
+        printf("Function offsets:\n");
+        for (int i = 0; i < vm.regChunk.functionCount; i++) {
+            printf("%d -> %d\n", i, vm.regChunk.functionOffsets[i]);
+        }
+#endif
+    }
     runRegisterVM(&vm.regVM);
     if (IS_ERROR(vm.lastError)) {
         result = INTERPRET_RUNTIME_ERROR;


### PR DESCRIPTION
## Summary
- align register VM dispatch table with opcode enum
- implement missing register opcodes used for subtraction and modulo
- add stubs for format print opcodes
- show register chunk when tracing

## Testing
- `make CFLAGS="-I./include -Wall -g -DDEBUG_TRACE_EXECUTION"`
- `bash tests/run_all_tests.sh`
