### PR TITLE
Fix register VM loops

### DIFF
--- a/src/compiler/reg_ir.c
+++ b/src/compiler/reg_ir.c
@@ -1402,7 +1402,7 @@ void chunkToRegisterIR(Chunk* chunk, RegisterChunk* out) {
                 uint16_t off = (uint16_t)(chunk->code[offset + 1] << 8 | chunk->code[offset + 2]);
                 RegisterInstr instr = {ROP_LOOP, 0, 0, 0};
                 writeRegisterInstr(out, instr);
-                patches[patchCount++] = (Patch){out->count - 1, offset - off};
+                patches[patchCount++] = (Patch){out->count - 1, offset + 3 - off};
                 offset += 3;
                 break;
             }

--- a/src/vm/reg_vm.c
+++ b/src/vm/reg_vm.c
@@ -443,6 +443,8 @@ op_PRINT_NO_NL:
 
 op_LOAD_GLOBAL:
     regs[ip->dst] = vm.globals[ip->src1];
+    if (IS_I64(regs[ip->dst])) i64_regs[ip->dst] = AS_I64(regs[ip->dst]);
+    if (IS_F64(regs[ip->dst])) f64_regs[ip->dst] = AS_F64(regs[ip->dst]);
     ip++;
     DISPATCH();
 
@@ -2427,6 +2429,10 @@ op_DIVIDE_NUMERIC: {
                 break;
             case ROP_LOAD_GLOBAL:
                 rvm->registers[instr.dst] = vm.globals[instr.src1];
+                if (IS_I64(rvm->registers[instr.dst]))
+                    rvm->i64_regs[instr.dst] = AS_I64(rvm->registers[instr.dst]);
+                if (IS_F64(rvm->registers[instr.dst]))
+                    rvm->f64_regs[instr.dst] = AS_F64(rvm->registers[instr.dst]);
                 break;
             case ROP_STORE_GLOBAL:
                 vm.globals[instr.dst] = rvm->registers[instr.src1];


### PR DESCRIPTION
## Summary
- fix register-based loop back-jump calculation
- sync typed registers on LOAD_GLOBAL

## Testing
- `make`
- `tests/run_all_tests.sh` *(fails: try_catch.orus, try_catch_message.orus)