### PR TITLE
Improve array index handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ include:
   from `string` or `nil` to numeric types is disallowed.
 - Integer literals automatically use `i32`, `i64` or `u64` based on value. A
   trailing `u` suffix forces an unsigned type.
+- Local variables without an explicit type annotation default to `i64` when the
+  initializer is an integer expression.
 
 The repository contains the interpreter sources and a large suite of example programs. A quick tour of the syntax lives in [`docs/LANGUAGE.md`](docs/LANGUAGE.md) and a step-by-step introduction is provided in [`docs/TUTORIAL.md`](docs/TUTORIAL.md). Notes on generics appear in [`docs/GENERICS.md`](docs/GENERICS.md) and more examples are spread throughout the test suite. See [`docs/TESTS_OVERVIEW.md`](docs/TESTS_OVERVIEW.md) for a list of categories. A potential compilation roadmap is outlined in [`docs/COMPILATION_ROADMAP.md`](docs/COMPILATION_ROADMAP.md). For a summary of built-in functions consult [`docs/BUILTINS.md`](docs/BUILTINS.md).
 
@@ -84,6 +86,10 @@ After building, run the interpreter in two ways:
 To trace individual register updates during execution, compile with
 `DEBUG_TRACE_EXECUTION` enabled in `reg_vm.c` and run the interpreter with
 the `--trace` flag or by setting `ORUS_TRACE=1`.
+
+When debugging array access issues you can additionally enable
+`DEBUG_ARRAY_INDEX` in `reg_vm.c` to log the chosen index and array length
+for every `ROP_ARRAY_GET` or `ROP_ARRAY_SET` instruction.
 
 ```
 

--- a/src/compiler/reg_ir.c
+++ b/src/compiler/reg_ir.c
@@ -924,9 +924,14 @@ void chunkToRegisterIR(Chunk* chunk, RegisterChunk* out) {
                 writeRegisterInstr(out, instr);
                 for (int i = count - 1; i >= 0; i--) {
                     int val = stackRegs[--sp];
-                    RegisterInstr set = {ROP_ARRAY_SET, (uint8_t)dst, (uint8_t)i, (uint8_t)val};
+                    int idxReg = ALLOC_REG();
+                    int idxConst = addRegisterConstant(out, I64_VAL(i));
+                    RegisterInstr loadIdx = {ROP_LOAD_CONST, (uint8_t)idxReg, (uint8_t)idxConst, 0};
+                    writeRegisterInstr(out, loadIdx);
+                    RegisterInstr set = {ROP_ARRAY_SET, (uint8_t)dst, (uint8_t)idxReg, (uint8_t)val};
                     writeRegisterInstr(out, set);
                     RELEASE_REG(val);
+                    RELEASE_REG(idxReg);
                 }
                 stackRegs[sp++] = dst;
                 offset += 2;
@@ -937,6 +942,7 @@ void chunkToRegisterIR(Chunk* chunk, RegisterChunk* out) {
                 int index = stackRegs[--sp];
                 int array = stackRegs[--sp];
                 int dst = ALLOC_REG();
+                /* Index registers must contain 64-bit integers. */
                 RegisterInstr instr = {ROP_ARRAY_GET, (uint8_t)dst, (uint8_t)array, (uint8_t)index};
                 writeRegisterInstr(out, instr);
                 RELEASE_REG(array);
@@ -950,6 +956,7 @@ void chunkToRegisterIR(Chunk* chunk, RegisterChunk* out) {
                 int value = stackRegs[--sp];
                 int index = stackRegs[--sp];
                 int array = stackRegs[--sp];
+                /* Index registers must contain 64-bit integers. */
                 RegisterInstr instr = {ROP_ARRAY_SET, (uint8_t)array, (uint8_t)index, (uint8_t)value};
                 writeRegisterInstr(out, instr);
                 RELEASE_REG(array);
@@ -1316,12 +1323,64 @@ void chunkToRegisterIR(Chunk* chunk, RegisterChunk* out) {
                 offset += 1;
                 break;
             }
+            case OP_LESS_I32: {
+                if (sp < 2) { offset++; break; }
+                int b = stackRegs[--sp];
+                int a = stackRegs[--sp];
+                int dst = ALLOC_REG();
+                RegisterInstr instr = {ROP_LESS_I32, (uint8_t)dst, (uint8_t)a, (uint8_t)b};
+                writeRegisterInstr(out, instr);
+                RELEASE_REG(a);
+                RELEASE_REG(b);
+                stackRegs[sp++] = dst;
+                offset += 1;
+                break;
+            }
+            case OP_LESS_U32: {
+                if (sp < 2) { offset++; break; }
+                int b = stackRegs[--sp];
+                int a = stackRegs[--sp];
+                int dst = ALLOC_REG();
+                RegisterInstr instr = {ROP_LESS_U32, (uint8_t)dst, (uint8_t)a, (uint8_t)b};
+                writeRegisterInstr(out, instr);
+                RELEASE_REG(a);
+                RELEASE_REG(b);
+                stackRegs[sp++] = dst;
+                offset += 1;
+                break;
+            }
             case OP_LESS_EQUAL_GENERIC: {
                 if (sp < 2) { offset++; break; }
                 int b = stackRegs[--sp];
                 int a = stackRegs[--sp];
                 int dst = ALLOC_REG();
                 RegisterInstr instr = {ROP_LESS_EQUAL_GENERIC, (uint8_t)dst, (uint8_t)a, (uint8_t)b};
+                writeRegisterInstr(out, instr);
+                RELEASE_REG(a);
+                RELEASE_REG(b);
+                stackRegs[sp++] = dst;
+                offset += 1;
+                break;
+            }
+            case OP_LESS_EQUAL_I32: {
+                if (sp < 2) { offset++; break; }
+                int b = stackRegs[--sp];
+                int a = stackRegs[--sp];
+                int dst = ALLOC_REG();
+                RegisterInstr instr = {ROP_LESS_EQUAL_I32, (uint8_t)dst, (uint8_t)a, (uint8_t)b};
+                writeRegisterInstr(out, instr);
+                RELEASE_REG(a);
+                RELEASE_REG(b);
+                stackRegs[sp++] = dst;
+                offset += 1;
+                break;
+            }
+            case OP_LESS_EQUAL_U32: {
+                if (sp < 2) { offset++; break; }
+                int b = stackRegs[--sp];
+                int a = stackRegs[--sp];
+                int dst = ALLOC_REG();
+                RegisterInstr instr = {ROP_LESS_EQUAL_U32, (uint8_t)dst, (uint8_t)a, (uint8_t)b};
                 writeRegisterInstr(out, instr);
                 RELEASE_REG(a);
                 RELEASE_REG(b);
@@ -1342,12 +1401,64 @@ void chunkToRegisterIR(Chunk* chunk, RegisterChunk* out) {
                 offset += 1;
                 break;
             }
+            case OP_GREATER_I32: {
+                if (sp < 2) { offset++; break; }
+                int b = stackRegs[--sp];
+                int a = stackRegs[--sp];
+                int dst = ALLOC_REG();
+                RegisterInstr instr = {ROP_GREATER_I32, (uint8_t)dst, (uint8_t)a, (uint8_t)b};
+                writeRegisterInstr(out, instr);
+                RELEASE_REG(a);
+                RELEASE_REG(b);
+                stackRegs[sp++] = dst;
+                offset += 1;
+                break;
+            }
+            case OP_GREATER_U32: {
+                if (sp < 2) { offset++; break; }
+                int b = stackRegs[--sp];
+                int a = stackRegs[--sp];
+                int dst = ALLOC_REG();
+                RegisterInstr instr = {ROP_GREATER_U32, (uint8_t)dst, (uint8_t)a, (uint8_t)b};
+                writeRegisterInstr(out, instr);
+                RELEASE_REG(a);
+                RELEASE_REG(b);
+                stackRegs[sp++] = dst;
+                offset += 1;
+                break;
+            }
             case OP_GREATER_EQUAL_GENERIC: {
                 if (sp < 2) { offset++; break; }
                 int b = stackRegs[--sp];
                 int a = stackRegs[--sp];
                 int dst = ALLOC_REG();
                 RegisterInstr instr = {ROP_GREATER_EQUAL_GENERIC, (uint8_t)dst, (uint8_t)a, (uint8_t)b};
+                writeRegisterInstr(out, instr);
+                RELEASE_REG(a);
+                RELEASE_REG(b);
+                stackRegs[sp++] = dst;
+                offset += 1;
+                break;
+            }
+            case OP_GREATER_EQUAL_I32: {
+                if (sp < 2) { offset++; break; }
+                int b = stackRegs[--sp];
+                int a = stackRegs[--sp];
+                int dst = ALLOC_REG();
+                RegisterInstr instr = {ROP_GREATER_EQUAL_I32, (uint8_t)dst, (uint8_t)a, (uint8_t)b};
+                writeRegisterInstr(out, instr);
+                RELEASE_REG(a);
+                RELEASE_REG(b);
+                stackRegs[sp++] = dst;
+                offset += 1;
+                break;
+            }
+            case OP_GREATER_EQUAL_U32: {
+                if (sp < 2) { offset++; break; }
+                int b = stackRegs[--sp];
+                int a = stackRegs[--sp];
+                int dst = ALLOC_REG();
+                RegisterInstr instr = {ROP_GREATER_EQUAL_U32, (uint8_t)dst, (uint8_t)a, (uint8_t)b};
                 writeRegisterInstr(out, instr);
                 RELEASE_REG(a);
                 RELEASE_REG(b);

--- a/src/vm/reg_vm.c
+++ b/src/vm/reg_vm.c
@@ -4,14 +4,15 @@
 #include "../../include/vm.h"
 #include "../../include/memory.h"
 #include "../../include/vm_ops.h"
-#include "../../include/vm_ops.h"
 #include "../../include/value.h"
 #include "../../include/modules.h"
 #include "../../include/builtins.h"
 #include <assert.h>
 #include <string.h>
 #include <stdio.h>
-#include <stdio.h>
+
+/* Enable to print array index details during execution */
+/* #define DEBUG_ARRAY_INDEX */
 
 #define SYNC_I64_REG(r) do { regs[(r)] = I64_VAL(i64_regs[(r)]); } while (0)
 #define SYNC_F64_REG(r) do { regs[(r)] = F64_VAL(f64_regs[(r)]); } while (0)
@@ -701,6 +702,10 @@ op_ARRAY_GET: {
     }
 
     ObjArray* arr = AS_ARRAY(arrayVal);
+#ifdef DEBUG_ARRAY_INDEX
+    printf("[DEBUG] GET index: i64[%d] = %ld, array length = %d\n",
+           ip->src2, index, arr->length);
+#endif
     if (index < 0 || index >= arr->length) {
         vmRuntimeError("Array index out of bounds.");
         goto HANDLE_RUNTIME_ERROR;
@@ -730,6 +735,10 @@ op_ARRAY_SET:
     }
 
     ObjArray* arr = AS_ARRAY(arrayVal);
+#ifdef DEBUG_ARRAY_INDEX
+    printf("[DEBUG] SET index: i64[%d] = %ld, array length = %d\n",
+           ip->src1, index, arr->length);
+#endif
     if (index < 0 || index >= arr->length) {
         vmRuntimeError("Array index out of bounds.");
         goto HANDLE_RUNTIME_ERROR;
@@ -2582,6 +2591,10 @@ op_DIVIDE_NUMERIC: {
                 }
 
                 ObjArray* arr = AS_ARRAY(arrayVal);
+#ifdef DEBUG_ARRAY_INDEX
+                printf("[DEBUG] GET index: i64[%d] = %ld, array length = %d\n",
+                       instr.src2, index, arr->length);
+#endif
                 if (index < 0 || index >= arr->length) {
                     vmRuntimeError("Array index out of bounds.");
                     goto check_error;
@@ -2610,6 +2623,10 @@ op_DIVIDE_NUMERIC: {
                 }
 
                 ObjArray* arr = AS_ARRAY(arrayVal);
+#ifdef DEBUG_ARRAY_INDEX
+                printf("[DEBUG] SET index: i64[%d] = %ld, array length = %d\n",
+                       instr.src1, index, arr->length);
+#endif
                 if (index < 0 || index >= arr->length) {
                     vmRuntimeError("Array index out of bounds.");
                     goto check_error;


### PR DESCRIPTION
## Summary
- ensure array constructor indexes are loaded into registers
- add register IR generation for i32 and u32 comparison ops
- optional debug prints for array index lookups
- document that untyped variables default to i64

## Testing
- `make orusc`
- `tests/run_all_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68556813b25483258201a89e7c101452